### PR TITLE
Explain that no struct can be created as transaction input other than some exceptions

### DIFF
--- a/book/src/concepts/what-is-a-transaction.md
+++ b/book/src/concepts/what-is-a-transaction.md
@@ -34,14 +34,14 @@ Transactions consist of:
 Transaction inputs are the arguments for the transaction and are split between 2 types:
 - Pure arguments: These are mostly [primitive types](../move-basics/primitive-types.html) with some
 extra additions. A pure argument can be:
-    - boolean
-    - integer (u8, u16, u32, u64, u128, u256)
-    - address
-    - std::ascii::String
-    - std::string::String
-    - vector of pure types
-    - Option of pure types
-    - ID, a special type that refers to a unique identifier of an object
+    - [`bool`](../move-basics/primitive-types.html#booleans).
+    - [integer](../move-basics/primitive-types.html#integers) (`u8`, `u16`, `u32`, `u64`, `u128`, `u256`).
+    - [`address`](../move-basics/address.html).
+    - [`std::string::String`](../move-basics/string.html), UTF8 strings.
+    - [`std::ascii::String`](../move-basics/string.html#ascii-strings), ASCII strings.
+    - [`vector<T>`](../move-basics/vector.html), where `T` is a pure type.
+    - [`std::option::Option<T>`](../move-basics/option.html), where `T` is a pure type.
+    - [`std::object::ID`](../storage/uid-and-id.html), takes part in the Unique IDentifier (UID) of an object. See also [What is an Object](../object/object-model.html).
 - Object arguments: These are objects or references of objects that the transaction will access. An
 object argument needs to be either a shared object, a frozen object, or an object that the
 transaction sender owns, in order for the transaction to be successfull.

--- a/book/src/concepts/what-is-a-transaction.md
+++ b/book/src/concepts/what-is-a-transaction.md
@@ -41,7 +41,7 @@ extra additions. A pure argument can be:
     - [`std::ascii::String`](../move-basics/string.html#ascii-strings), ASCII strings.
     - [`vector<T>`](../move-basics/vector.html), where `T` is a pure type.
     - [`std::option::Option<T>`](../move-basics/option.html), where `T` is a pure type.
-    - [`std::object::ID`](../storage/uid-and-id.html), takes part in the Unique IDentifier (UID) of an object. See also [What is an Object](../object/object-model.html).
+    - [`std::object::ID`](../storage/uid-and-id.html), typically points to an object. See also [What is an Object](../object/object-model.html).
 - Object arguments: These are objects or references of objects that the transaction will access. An
 object argument needs to be either a shared object, a frozen object, or an object that the
 transaction sender owns, in order for the transaction to be successfull.

--- a/book/src/concepts/what-is-a-transaction.md
+++ b/book/src/concepts/what-is-a-transaction.md
@@ -24,7 +24,7 @@ Transactions consist of:
 
 - a sender - the [account](./what-is-an-account.md) that _signs_ the transaction;
 - a list (or a chain) of commands - the operations to be executed;
-- command inputs - the arguments for the commands: either `pure` - simple* values like numbers or
+- command inputs - the arguments for the commands: either `pure` - simple values like numbers or
   strings, or `object` - objects that the transaction will access;
 - a gas object - the `Coin` object used to pay for the transaction;
 - gas price and budget - the cost of the transaction;
@@ -32,6 +32,27 @@ Transactions consist of:
 <sup>* Notice that custom structures defined in Move packages cannot be created and passed to
 MoveVM as transaction inputs. They always need to be instantiated/created inside MoveVM. There are
 only some exceptions to this such as: `ID` and `String`</sup>
+
+## Inputs
+
+Transaction inputs are the arguments for the transaction and are split between 2 types:
+- Pure arguments: These are mostly [primitive types](../move-basics/primitive-types.html) with some
+extra additions. A pure argument can be:
+    - boolean
+    - integer (u8, u16, u32, u64, u128, u256)
+    - address
+    - std::ascii::String
+    - std::string::String
+    - vector of the above types
+    - Option of the above types
+    - ID, a special type that refers to a unique identifier of an object
+- Object arguments: These are objects or references of objects that the transaction will access. An
+object argument needs to be either a shared object, a frozen object, or an object that the
+transaction sender owns, in order for the transaction to be successfull.
+For more see [Object Model](http://localhost:3000/object/index.html).
+
+Note that a single command inside a transaction can also have a previous command's result as input.
+These results/inputs can be anything from a simple value, an object, or any kind of Move struct.
 
 ## Commands
 

--- a/book/src/concepts/what-is-a-transaction.md
+++ b/book/src/concepts/what-is-a-transaction.md
@@ -29,10 +29,6 @@ Transactions consist of:
 - a gas object - the `Coin` object used to pay for the transaction;
 - gas price and budget - the cost of the transaction;
 
-<sup>* Notice that custom structures defined in Move packages cannot be created and passed to
-MoveVM as transaction inputs. They always need to be instantiated/created inside MoveVM. There are
-only some exceptions to this such as: `ID` and `String`</sup>
-
 ## Inputs
 
 Transaction inputs are the arguments for the transaction and are split between 2 types:

--- a/book/src/concepts/what-is-a-transaction.md
+++ b/book/src/concepts/what-is-a-transaction.md
@@ -47,9 +47,6 @@ object argument needs to be either a shared object, a frozen object, or an objec
 transaction sender owns, in order for the transaction to be successfull.
 For more see [Object Model](http://localhost:3000/object/index.html).
 
-Note that a single command inside a transaction can also have a previous command's result as input.
-These results/inputs can be anything from a simple value, an object, or any kind of Move struct.
-
 ## Commands
 
 Sui transactions may consist of multiple commands. Each command is a single built-in command (like

--- a/book/src/concepts/what-is-a-transaction.md
+++ b/book/src/concepts/what-is-a-transaction.md
@@ -45,7 +45,7 @@ extra additions. A pure argument can be:
 - Object arguments: These are objects or references of objects that the transaction will access. An
 object argument needs to be either a shared object, a frozen object, or an object that the
 transaction sender owns, in order for the transaction to be successfull.
-For more see [Object Model](http://localhost:3000/object/index.html).
+For more see [Object Model](../object/index.html).
 
 ## Commands
 

--- a/book/src/concepts/what-is-a-transaction.md
+++ b/book/src/concepts/what-is-a-transaction.md
@@ -43,8 +43,8 @@ extra additions. A pure argument can be:
     - address
     - std::ascii::String
     - std::string::String
-    - vector of the above types
-    - Option of the above types
+    - vector of pure types
+    - Option of pure types
     - ID, a special type that refers to a unique identifier of an object
 - Object arguments: These are objects or references of objects that the transaction will access. An
 object argument needs to be either a shared object, a frozen object, or an object that the

--- a/book/src/concepts/what-is-a-transaction.md
+++ b/book/src/concepts/what-is-a-transaction.md
@@ -24,10 +24,14 @@ Transactions consist of:
 
 - a sender - the [account](./what-is-an-account.md) that _signs_ the transaction;
 - a list (or a chain) of commands - the operations to be executed;
-- command inputs - the arguments for the commands: either `pure` - simple values like numbers or
+- command inputs - the arguments for the commands: either `pure` - simple* values like numbers or
   strings, or `object` - objects that the transaction will access;
 - a gas object - the `Coin` object used to pay for the transaction;
 - gas price and budget - the cost of the transaction;
+
+<sup>* Notice that custom structures defined in Move packages cannot be created and passed to
+MoveVM as transaction inputs. They always need to be instantiated/created inside MoveVM. There are
+only some exceptions to this such as: `ID` and `String`</sup>
 
 ## Commands
 

--- a/book/src/programmability/bcs.md
+++ b/book/src/programmability/bcs.md
@@ -52,6 +52,8 @@ Structs encode similarly to simple types. Here is how to encode a struct using B
 {{#include ../../../packages/samples/sources/programmability/bcs.move:encode_struct}}
 ```
 
+Note that encoding a struct does not make much sense in interacting with the Move VM, as custom structs cannot be created this way to use in MoveVM. See also [Transaction](../concepts/what-is-a-transaction.html).
+
 ## Decoding
 
 Because BCS does not self-describe and Move is statically typed, decoding requires prior knowledge of the data type. The `sui::bcs` module provides various functions to assist with this process.

--- a/book/src/programmability/bcs.md
+++ b/book/src/programmability/bcs.md
@@ -53,7 +53,7 @@ Structs encode similarly to simple types. Here is how to encode a struct using B
 ```
 
 Note that encoding a custom struct does not make much sense in interacting with the Move VM, as
-custom structs cannot be created this way to use in MoveVM. See also
+they cannot be created this way to use in Move VM. See also
 [Transaction Inputs](../concepts/what-is-a-transaction.html#inputs).
 
 ## Decoding

--- a/book/src/programmability/bcs.md
+++ b/book/src/programmability/bcs.md
@@ -52,10 +52,6 @@ Structs encode similarly to simple types. Here is how to encode a struct using B
 {{#include ../../../packages/samples/sources/programmability/bcs.move:encode_struct}}
 ```
 
-Note that encoding a custom struct does not make much sense in interacting with the Move VM, as
-they cannot be created this way to use in Move VM. See also
-[Transaction Inputs](../concepts/what-is-a-transaction.html#inputs).
-
 ## Decoding
 
 Because BCS does not self-describe and Move is statically typed, decoding requires prior knowledge of the data type. The `sui::bcs` module provides various functions to assist with this process.

--- a/book/src/programmability/bcs.md
+++ b/book/src/programmability/bcs.md
@@ -52,7 +52,9 @@ Structs encode similarly to simple types. Here is how to encode a struct using B
 {{#include ../../../packages/samples/sources/programmability/bcs.move:encode_struct}}
 ```
 
-Note that encoding a struct does not make much sense in interacting with the Move VM, as custom structs cannot be created this way to use in MoveVM. See also [Transaction](../concepts/what-is-a-transaction.html).
+Note that encoding a custom struct does not make much sense in interacting with the Move VM, as
+custom structs cannot be created this way to use in MoveVM. See also
+[Transaction Inputs](../concepts/what-is-a-transaction.html#inputs).
 
 ## Decoding
 


### PR DESCRIPTION
I happened to waste some time in my move learning process trying to see whether structs with `copy` ability could be created from the client side and passed into MoveVM. A colleague did the same thing too. Maybe we need to make this explicit.

I am not sure whether the format and places I used are the best.