### PR TITLE
fix(typos): Correct spelling errors in CSS, Move, and Markdown files

### DIFF
--- a/packages/samples/sources/move-basics/copy-ability.move
+++ b/packages/samples/sources/move-basics/copy-ability.move
@@ -16,7 +16,7 @@ let b = a;   // `a` is copied to `b`
 let c = *&b; // explicit copy via dereference operator
 
 // Copyable doesn't have the `drop` ability, so every instance (a, b, and c) must
-// be used or explicity destructured. The `drop` ability is explained below.
+// be used or explicitly destructured. The `drop` ability is explained below.
 let Copyable {} = a;
 let Copyable {} = b;
 let Copyable {} = c;

--- a/reference/src/abort-and-assert/clever-errors.md
+++ b/reference/src/abort-and-assert/clever-errors.md
@@ -95,7 +95,7 @@ fun abort_no_code() {
 Both of these will produce a `u64` abort code value that holds:
 
 1. A set tag-bit that indicates that the abort code is a clever abort code.
-2. The line number of where the abort occured in the source file (e.g., 6).
+2. The line number of where the abort occurred in the source file (e.g., 6).
 3. A sentinel value of `0xffff` for the index into the module's identifier table for the constant's
    name.
 4. A sentinel value of `0xffff` for the index of the constant's value in the module's constant

--- a/theme/css/chrome.css
+++ b/theme/css/chrome.css
@@ -434,7 +434,7 @@ ul#searchresults span.teaser em {
 
 .chapter li {
     display: flex;
-    color: var(--sidebar-non-existant);
+    color: var(--sidebar-non-existent);
 }
 .chapter li a {
     display: block;

--- a/theme/css/variables.css
+++ b/theme/css/variables.css
@@ -25,7 +25,7 @@
 
     --sidebar-bg: #14191f;
     --sidebar-fg: #c8c9db;
-    --sidebar-non-existant: #5c6773;
+    --sidebar-non-existent: #5c6773;
     --sidebar-active: #ffb454;
     --sidebar-spacer: #2d334f;
 
@@ -65,7 +65,7 @@
 
     --sidebar-bg: #292c2f;
     --sidebar-fg: #a1adb8;
-    --sidebar-non-existant: #505254;
+    --sidebar-non-existent: #505254;
     --sidebar-active: #3473ad;
     --sidebar-spacer: #393939;
 
@@ -105,7 +105,7 @@
 
     --sidebar-bg: #fff;
     --sidebar-fg: hsl(0, 0%, 0%);
-    --sidebar-non-existant: #aaaaaa;
+    --sidebar-non-existent: #aaaaaa;
     --sidebar-active: #1f1fff;
     --sidebar-spacer: #f4f4f4;
 
@@ -145,7 +145,7 @@
 
     --sidebar-bg: #282d3f;
     --sidebar-fg: #c8c9db;
-    --sidebar-non-existant: #505274;
+    --sidebar-non-existent: #505274;
     --sidebar-active: #2b79a2;
     --sidebar-spacer: #2d334f;
 
@@ -185,7 +185,7 @@
 
     --sidebar-bg: #3b2e2a;
     --sidebar-fg: #c8c9db;
-    --sidebar-non-existant: #505254;
+    --sidebar-non-existent: #505254;
     --sidebar-active: #e69f67;
     --sidebar-spacer: #45373a;
 
@@ -226,7 +226,7 @@
 
         --sidebar-bg: #292c2f;
         --sidebar-fg: #a1adb8;
-        --sidebar-non-existant: #505254;
+        --sidebar-non-existent: #505254;
         --sidebar-active: #3473ad;
         --sidebar-spacer: #393939;
 


### PR DESCRIPTION
- Fixed `non-existant` → `non-existent` in `variables.css` and `chrome.css`.
- Corrected `explicity` → `explicitly` in `copy-ability.move`.
- Fixed `occured` → `occurred` in `clever-errors.md`.