### PR TITLE
chore: rename newtype to wrapper type

### DIFF
--- a/book/src/programmability/collections.md
+++ b/book/src/programmability/collections.md
@@ -76,5 +76,5 @@ if the two `VecSet` instances contain the same elements.
 
 ## Next Steps
 
-In the next section we will cover the [Newtype Pattern](./newtype-pattern.md) - a design pattern
+In the next section we will cover the [Wrapper Type Pattern](./wrapper-type-pattern.md) - a design pattern
 often used with collection types to extend or restrict their behavior. 

--- a/book/src/programmability/wrapper-type-pattern.md
+++ b/book/src/programmability/wrapper-type-pattern.md
@@ -50,7 +50,7 @@ extend the behavior of an existing type. However, it does have some limitations:
 
 ## Next Steps
 
-The newtype pattern is very useful, particularly when used in conjunction with collection types, as
+The wrapper type pattern is very useful, particularly when used in conjunction with collection types, as
 demonstrated in the previous section. In the next section, we will cover
 [Dynamic Fields](./dynamic-fields.md) — an important primitive that enables
 [Dynamic Collections](./dynamic-collections.md), a way to store large collections of data in a more


### PR DESCRIPTION
Fixes minor leftovers from when the wrapper type pattern was presumably called "Newtype pattern". It was a bit confusing when reading the docs 😄 