### PR TITLE
Update generics.move

### DIFF
--- a/packages/samples/sources/move-basics/generics.move
+++ b/packages/samples/sources/move-basics/generics.move
@@ -5,7 +5,7 @@ module book::generics;
 
 // ANCHOR: container
 /// Container for any type `T`.
-public struct Container<T> has drop {
+public struct Container<T> has drop, store {
     value: T,
 }
 


### PR DESCRIPTION
Container should have store ability so that container.value should be accessible in test_container test method.