### PR TITLE
[book] Correcting code samples

### DIFF
--- a/book/src/README.md
+++ b/book/src/README.md
@@ -2,7 +2,7 @@
 
 <!-- TODO: insert author(s) -->
 
-This is the Move Book - a comprehensive guide to the Move programming language and the Sui
+This is The Move Book - a comprehensive guide to the Move programming language and the Sui
 blockchain. The book is intended for developers who are interested in learning about Move and
 building on Sui.
 

--- a/book/src/README.md
+++ b/book/src/README.md
@@ -2,11 +2,15 @@
 
 <!-- TODO: insert author(s) -->
 
-This is the Move Book - a comprehensive guide to the Move programming language and the Sui blockchain. The book is intended for developers who are interested in learning about Move and building on Sui.
+This is the Move Book - a comprehensive guide to the Move programming language and the Sui
+blockchain. The book is intended for developers who are interested in learning about Move and
+building on Sui.
 
 <div class="warning">
 
-The book is in active development and a work in progress. If you have any feedback or suggestions, feel free to open an issue or a pull request on the [GitHub repository](https://github.com/MystenLabs/move-book).
+The book is in active development and a work in progress. If you have any feedback or suggestions,
+feel free to open an issue or a pull request on the
+[GitHub repository](https://github.com/MystenLabs/move-book).
 
 </div>
 

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -108,7 +108,7 @@
   - [Pattern: Witness](./programmability/witness-pattern.md)
   - [One Time Witness](./programmability/one-time-witness.md)
   - [Publisher Authority](./programmability/publisher.md)
-  - [Display](./programmability/display.md) <!-- End Block: from Witness to Display -->
+  - [Object Display](./programmability/display.md) <!-- End Block: from Witness to Display -->
   - [Events](./programmability/events.md)
   - [Balance & Coin]() <!-- ./programmability/balance-and-coin.md) -->
   - [Sui Framework](./programmability/sui-framework.md)

--- a/book/src/before-we-begin/move-2024.md
+++ b/book/src/before-we-begin/move-2024.md
@@ -1,8 +1,8 @@
 # Move 2024
 
-Move 2024 is the current edition of the Move language maintained by Mysten Labs. All of the examples in
-this book are written in Move 2024. If you're used to the pre-2024 version of Move, please, refer to
-the [Move 2024 Migration Guide](./../guides/2024-migration-guide.md) to learn about the changes and
-improvements in the new edition.
+Move 2024 is the current edition of the Move language maintained by Mysten Labs. All of the examples
+in this book are written in Move 2024. If you're used to the pre-2024 version of Move, please, refer
+to the [Move 2024 Migration Guide](./../guides/2024-migration-guide.md) to learn about the changes
+and improvements in the new edition.
 
 <!-- Notes ? -->

--- a/book/src/before-we-begin/move-2024.md
+++ b/book/src/before-we-begin/move-2024.md
@@ -1,7 +1,7 @@
 # Move 2024
 
 Move 2024 is the current edition of the Move language maintained by Mysten Labs. All of the examples
-in this book are written in Move 2024. If you're used to the pre-2024 version of Move, please, refer
+in this book are written in Move 2024. If you're used to the pre-2024 version of Move, refer
 to the [Move 2024 Migration Guide](./../guides/2024-migration-guide.md) to learn about the changes
 and improvements in the new edition.
 

--- a/book/src/concepts/address.md
+++ b/book/src/concepts/address.md
@@ -54,7 +54,7 @@ Here are some examples of reserved addresses:
 
 > You can find all reserved addresses in the [Appendix B](../appendix/reserved-addresses.md).
 
-## Further reading
+## Further Reading
 
 - [Address type](../move-basics/address.md) in Move
 - [sui::address module](https://docs.sui.io/references/framework/sui/address)

--- a/book/src/concepts/manifest.md
+++ b/book/src/concepts/manifest.md
@@ -54,17 +54,17 @@ Packages also import addresses from other packages. For example, the Sui depende
 and `sui` addresses to the project. These addresses can be used in the code as aliases for the
 addresses.
 
-Starting with version 1.45 of the Sui CLI, the Sui system packages (`std`,
-`sui`, `system`, `bridge`, and `deepbook`) are automatically added as
-dependencies if none of them are explicitly listed.
+Starting with version 1.45 of the Sui CLI, the Sui system packages (`std`, `sui`, `system`,
+`bridge`, and `deepbook`) are automatically added as dependencies if none of them are explicitly
+listed.
 
-### Resolving version conflicts with override
+### Resolving Version Conflicts with Override
 
 Sometimes dependencies have conflicting versions of the same package. For example, if you have two
-dependencies that use different versions of the Example package, you can override the dependency in the
-`[dependencies]` section. To do so, add the `override` field to the dependency. The version of the
-dependency specified in the `[dependencies]` section will be used instead of the one specified in
-the dependency itself.
+dependencies that use different versions of the Example package, you can override the dependency in
+the `[dependencies]` section. To do so, add the `override` field to the dependency. The version of
+the dependency specified in the `[dependencies]` section will be used instead of the one specified
+in the dependency itself.
 
 ```toml
 [dependencies]
@@ -91,7 +91,7 @@ modes. Important to note that it is impossible to introduce new aliases in this 
 override the existing ones. So in the example above, if you add `alice = "0xB0B"` to this section,
 the `alice` address will be `0xB0B` in the test and dev modes, and `0xA11CE` in the regular build.
 
-## TOML styles
+## TOML Styles
 
 The TOML format supports two styles for tables: inline and multiline. The examples above are using
 the inline style, but it is also possible to use the multiline style. You wouldn't want to use it

--- a/book/src/concepts/packages.md
+++ b/book/src/concepts/packages.md
@@ -16,8 +16,8 @@
 
 -->
 
-Move is a language for writing smart contracts - programs that are stored and run on the blockchain. A
-single program is organized into a package. A package is published on the blockchain and is
+Move is a language for writing smart contracts - programs that are stored and run on the blockchain.
+A single program is organized into a package. A package is published on the blockchain and is
 identified by an [address](./address.md). A published package can be interacted with by sending
 [transactions](./what-is-a-transaction.md) calling its functions. It can also act as a dependency
 for other packages.

--- a/book/src/concepts/what-is-a-transaction.md
+++ b/book/src/concepts/what-is-a-transaction.md
@@ -46,7 +46,7 @@ Transaction inputs are the arguments for the transaction and are split between 2
   [What is an Object](../object/object-model.html).
 - Object arguments: These are objects or references of objects that the transaction will access. An
   object argument needs to be either a shared object, a frozen object, or an object that the
-  transaction sender owns, in order for the transaction to be successful. For more see
+  transaction sender owns for the transaction to be successful. For more see
   [Object Model](../object/index.html).
 
 ## Commands

--- a/book/src/concepts/what-is-a-transaction.md
+++ b/book/src/concepts/what-is-a-transaction.md
@@ -32,20 +32,22 @@ Transactions consist of:
 ## Inputs
 
 Transaction inputs are the arguments for the transaction and are split between 2 types:
+
 - Pure arguments: These are mostly [primitive types](../move-basics/primitive-types.html) with some
-extra additions. A pure argument can be:
-    - [`bool`](../move-basics/primitive-types.html#booleans).
-    - [unsigned integer](../move-basics/primitive-types.html#integer-types) (`u8`, `u16`, `u32`, `u64`, `u128`, `u256`).
-    - [`address`](../move-basics/address.html).
-    - [`std::string::String`](../move-basics/string.html), UTF8 strings.
-    - [`std::ascii::String`](../move-basics/string.html#ascii-strings), ASCII strings.
-    - [`vector<T>`](../move-basics/vector.html), where `T` is a pure type.
-    - [`std::option::Option<T>`](../move-basics/option.html), where `T` is a pure type.
-    - [`std::object::ID`](../storage/uid-and-id.html), typically points to an object. See also [What is an Object](../object/object-model.html).
+  extra additions. A pure argument can be: -
+  [`bool`](../move-basics/primitive-types.html#booleans). -
+  [unsigned integer](../move-basics/primitive-types.html#integer-types) (`u8`, `u16`, `u32`, `u64`,
+  `u128`, `u256`). - [`address`](../move-basics/address.html). -
+  [`std::string::String`](../move-basics/string.html), UTF8 strings. -
+  [`std::ascii::String`](../move-basics/string.html#ascii-strings), ASCII strings. -
+  [`vector<T>`](../move-basics/vector.html), where `T` is a pure type. -
+  [`std::option::Option<T>`](../move-basics/option.html), where `T` is a pure type. -
+  [`std::object::ID`](../storage/uid-and-id.html), typically points to an object. See also
+  [What is an Object](../object/object-model.html).
 - Object arguments: These are objects or references of objects that the transaction will access. An
-object argument needs to be either a shared object, a frozen object, or an object that the
-transaction sender owns, in order for the transaction to be successful.
-For more see [Object Model](../object/index.html).
+  object argument needs to be either a shared object, a frozen object, or an object that the
+  transaction sender owns, in order for the transaction to be successful. For more see
+  [Object Model](../object/index.html).
 
 ## Commands
 

--- a/book/src/guides/2024-migration-guide.md
+++ b/book/src/guides/2024-migration-guide.md
@@ -32,7 +32,7 @@ $ sui move migrate
 The migration tool will update the code to use the `let mut` syntax, the new `public` modifier for
 structs, and the `public(package)` function visibility instead of `friend` declarations.
 
-## Mutable bindings with `let mut`
+## Mutable Bindings with `let mut`
 
 Move 2024 introduces `let mut` syntax to declare mutable variables. The `let mut` syntax is used to
 declare a mutable variable that can be changed after it is declared.

--- a/book/src/guides/better-error-handling.md
+++ b/book/src/guides/better-error-handling.md
@@ -1,4 +1,4 @@
-# Better error handling
+# Better Error Handling
 
 Whenever execution encounters an abort, transaction fails and abort code is returned to the caller.
 Move VM returns the module name that aborted the transaction and the abort code. This behavior is
@@ -8,16 +8,16 @@ call aborted the transaction, and it will be hard to debug the issue or provide 
 message to the user.
 
 ```move
-module book::module_a {
-    use book::module_b;
+module book::module_a;
 
-    public fun do_something() {
-        let field_1 = module_b::get_field(1); // may abort with 0
-        /* ... a lot of logic ... */
-        let field_2 = module_b::get_field(2); // may abort with 0
-        /* ... some more logic ... */
-        let field_3 = module_b::get_field(3); // may abort with 0
-    }
+use book::module_b;
+
+public fun do_something() {
+    let field_1 = module_b::get_field(1); // may abort with 0
+    /* ... a lot of logic ... */
+    let field_2 = module_b::get_field(2); // may abort with 0
+    /* ... some more logic ... */
+    let field_3 = module_b::get_field(3); // may abort with 0
 }
 ```
 
@@ -26,7 +26,7 @@ abort. If the caller of the `do_something` function receives an abort code `0`, 
 understand which call to `module_b::get_field` aborted the transaction. To address this problem,
 there are common patterns that can be used to improve error handling.
 
-## Rule 1: Handle all possible scenarios
+## Rule 1: Handle All Possible Scenarios
 
 It is considered a good practice to provide a safe "check" function that returns a boolean value
 indicating whether an operation can be performed safely. If the `module_b` provides a function
@@ -34,51 +34,51 @@ indicating whether an operation can be performed safely. If the `module_b` provi
 function can be rewritten as follows:
 
 ```move
-module book::module_a {
-    use book::module_b;
+module book::module_a;
 
-    const ENoField: u64 = 0;
+use book::module_b;
 
-    public fun do_something() {
-        assert!(module_b::has_field(1), ENoField);
-        let field_1 = module_b::get_field(1);
-        /* ... */
-        assert!(module_b::has_field(2), ENoField);
-        let field_2 = module_b::get_field(2);
-        /* ... */
-        assert!(module_b::has_field(3), ENoField);
-        let field_3 = module_b::get_field(3);
-    }
+const ENoField: u64 = 0;
+
+public fun do_something() {
+    assert!(module_b::has_field(1), ENoField);
+    let field_1 = module_b::get_field(1);
+    /* ... */
+    assert!(module_b::has_field(2), ENoField);
+    let field_2 = module_b::get_field(2);
+    /* ... */
+    assert!(module_b::has_field(3), ENoField);
+    let field_3 = module_b::get_field(3);
 }
 ```
 
 By adding custom checks before each call to `module_b::get_field`, the developer of the `module_a`
 takes control over the error handling. And it allows implementing the second rule.
 
-## Rule 2: Abort with different codes
+## Rule 2: Abort with Different Codes
 
 The second trick, once the abort codes are handled by the caller module, is to use different abort
 codes for different scenarios. This way, the caller module can provide a meaningful error message to
 the user. The `module_a` can be rewritten as follows:
 
 ```move
-module book::module_a {
-    use book::module_b;
+module book::module_a;
 
-    const ENoFieldA: u64 = 0;
-    const ENoFieldB: u64 = 1;
-    const ENoFieldC: u64 = 2;
+use book::module_b;
 
-    public fun do_something() {
-        assert!(module_b::has_field(1), ENoFieldA);
-        let field_1 = module_b::get_field(1);
-        /* ... */
-        assert!(module_b::has_field(2), ENoFieldB);
-        let field_2 = module_b::get_field(2);
-        /* ... */
-        assert!(module_b::has_field(3), ENoFieldC);
-        let field_3 = module_b::get_field(3);
-    }
+const ENoFieldA: u64 = 0;
+const ENoFieldB: u64 = 1;
+const ENoFieldC: u64 = 2;
+
+public fun do_something() {
+    assert!(module_b::has_field(1), ENoFieldA);
+    let field_1 = module_b::get_field(1);
+    /* ... */
+    assert!(module_b::has_field(2), ENoFieldB);
+    let field_2 = module_b::get_field(2);
+    /* ... */
+    assert!(module_b::has_field(3), ENoFieldC);
+    let field_3 = module_b::get_field(3);
 }
 ```
 
@@ -86,7 +86,7 @@ Now, the caller module can provide a meaningful error message to the user. If th
 abort code `0`, it can be translated to "Field 1 does not exist". If the caller receives an abort
 code `1`, it can be translated to "Field 2 does not exist". And so on.
 
-## Rule 3: Return bool instead of assert
+## Rule 3: Return `bool` Instead of `assert`
 
 A developer is often tempted to add a public function that would assert all the conditions and abort
 the execution. However, it is a better practice to create a function that returns a boolean value
@@ -94,52 +94,51 @@ instead. This way, the caller module can handle the error and provide a meaningf
 the user.
 
 ```move
-module book::some_app_assert {
+module book::some_app_assert;
 
-    const ENotAuthorized: u64 = 0;
+const ENotAuthorized: u64 = 0;
 
-    public fun do_a() {
-        assert_is_authorized();
-        // ...
-    }
+public fun do_a() {
+    assert_is_authorized();
+    // ...
+}
 
-    public fun do_b() {
-        assert_is_authorized();
-        // ...
-    }
+public fun do_b() {
+    assert_is_authorized();
+    // ...
+}
 
-    /// Don't do this
-    public fun assert_is_authorized() {
-        assert!(/* some condition */ true, ENotAuthorized);
-    }
+/// Don't do this
+public fun assert_is_authorized() {
+    assert!(/* some condition */ true, ENotAuthorized);
 }
 ```
 
 This module can be rewritten as follows:
 
 ```move
-module book::some_app {
-    const ENotAuthorized: u64 = 0;
+module book::some_app;
 
-    public fun do_a() {
-        assert!(is_authorized(), ENotAuthorized);
-        // ...
-    }
+const ENotAuthorized: u64 = 0;
 
-    public fun do_b() {
-        assert!(is_authorized(), ENotAuthorized);
-        // ...
-    }
+public fun do_a() {
+    assert!(is_authorized(), ENotAuthorized);
+    // ...
+}
 
-    public fun is_authorized(): bool {
-        /* some condition */ true
-    }
+public fun do_b() {
+    assert!(is_authorized(), ENotAuthorized);
+    // ...
+}
 
-    // a private function can still be used to avoid code duplication for a case
-    // when the same condition with the same abort code is used in multiple places
-    fun assert_is_authorized() {
-        assert!(is_authorized(), ENotAuthorized);
-    }
+public fun is_authorized(): bool {
+    /* some condition */ true
+}
+
+// a private function can still be used to avoid code duplication for a case
+// when the same condition with the same abort code is used in multiple places
+fun assert_is_authorized() {
+    assert!(is_authorized(), ENotAuthorized);
 }
 ```
 

--- a/book/src/guides/building-against-limits.md
+++ b/book/src/guides/building-against-limits.md
@@ -1,4 +1,4 @@
-# Building against Limits
+# Building Against Limits
 
 To guarantee the safety and security of the network, Sui has certain limits and restrictions. These
 limits are in place to prevent abuse and to ensure that the network remains stable and efficient.
@@ -30,7 +30,7 @@ that a single address is 32 bytes), it needs to be joined dynamically either in 
 in a Move function. Standard functions like `vector::append()` can join two vectors of ~16KB
 resulting in a ~32KB of data as a single value.
 
-## Maximum Number of Objects (and dynamic fields) created
+## Maximum Number of Objects (and Dynamic Fields) Created
 
 The maximum number of objects that can be created in a single transaction is 2048. If a transaction
 attempts to create more than 2048 objects, it will be rejected by the network. This also affects
@@ -38,7 +38,7 @@ attempts to create more than 2048 objects, it will be rejected by the network. T
 So the maximum number of [dynamic fields](./../programmability/dynamic-fields.md) that can be
 created in a single transaction is 1000. The limitation applies to dynamic object fields as well.
 
-## Maximum Number of Dynamic Fields accessed
+## Maximum Number of Dynamic Fields Accessed
 
 The maximum number of dynamic fields that can be accessed in a single transaction is 1000. If a
 transaction attempts to access more than 1000 dynamic fields, it will be rejected by the network.

--- a/book/src/guides/upgradeability-practices.md
+++ b/book/src/guides/upgradeability-practices.md
@@ -42,7 +42,7 @@ public(package) fun create_book_package(ctx: &mut TxContext): Book {
     create_book_internal(ctx)
 }
 
-// entry functions can be removed and changed as long they're not public
+// entry functions can be removed and changed as long as they're not public
 entry fun create_book_entry(ctx: &mut TxContext): Book {
     create_book_internal(ctx)
 }

--- a/book/src/guides/upgradeability-practices.md
+++ b/book/src/guides/upgradeability-practices.md
@@ -9,47 +9,47 @@ functions - they can be called from other packages.
 
 ```move
 // module can not be removed from the package
-module book::upgradable {
-    // dependencies can be changed (if they are not used in public signatures)
-    use std::string::String;
-    use sui::event; // can be removed
+module book::upgradable;
 
-    // public structs can not be removed and can't be changed
-    public struct Book has key {
-        id: UID,
-        title: String,
-    }
+// dependencies can be changed (if they are not used in public signatures)
+use std::string::String;
+use sui::event; // can be removed
 
-    // public structs can not be removed and can't be changed
-    public struct BookCreated has copy, drop {
+// public structs can not be removed and can't be changed
+public struct Book has key {
+    id: UID,
+    title: String,
+}
+
+// public structs can not be removed and can't be changed
+public struct BookCreated has copy, drop {
+    /* ... */
+}
+
+// public functions can not be removed and their signature can never change
+// but the implementation can be changed
+public fun create_book(ctx: &mut TxContext): Book {
+    create_book_internal(ctx)
+
+    // can be removed and changed
+    event::emit(BookCreated {
         /* ... */
-    }
+    })
+}
 
-    // public functions can not be removed and their signature can never change
-    // but the implementation can be changed
-    public fun create_book(ctx: &mut TxContext): Book {
-        create_book_internal(ctx)
+// package-visibility functions can be removed and changed
+public(package) fun create_book_package(ctx: &mut TxContext): Book {
+    create_book_internal(ctx)
+}
 
-        // can be removed and changed
-        event::emit(BookCreated {
-            /* ... */
-        })
-    }
+// entry functions can be removed and changed as long they're not public
+entry fun create_book_entry(ctx: &mut TxContext): Book {
+    create_book_internal(ctx)
+}
 
-    // package-visibility functions can be removed and changed
-    public(package) fun create_book_package(ctx: &mut TxContext): Book {
-        create_book_internal(ctx)
-    }
-
-    // entry functions can be removed and changed as long they're not public
-    entry fun create_book_entry(ctx: &mut TxContext): Book {
-        create_book_internal(ctx)
-    }
-
-    // private functions can be removed and changed
-    fun create_book_internal(ctx: &mut TxContext): Book {
-        abort 0
-    }
+// private functions can be removed and changed
+fun create_book_internal(ctx: &mut TxContext): Book {
+    abort 0
 }
 ```
 
@@ -70,23 +70,22 @@ be used to update the version of the shared state, so that the new version of co
 the old version aborts with a version mismatch.
 
 ```move
-module book::versioned_state {
+module book::versioned_state;
 
-    const EVersionMismatch: u64 = 0;
+const EVersionMismatch: u64 = 0;
 
-    const VERSION: u8 = 1;
+const VERSION: u8 = 1;
 
-    /// The shared state (can be owned too)
-    public struct SharedState has key {
-        id: UID,
-        version: u8,
-        /* ... */
-    }
+/// The shared state (can be owned too)
+public struct SharedState has key {
+    id: UID,
+    version: u8,
+    /* ... */
+}
 
-    public fun mutate(state: &mut SharedState) {
-        assert!(state.version == VERSION, EVersionMismatch);
-        // ...
-    }
+public fun mutate(state: &mut SharedState) {
+    assert!(state.version == VERSION, EVersionMismatch);
+    // ...
 }
 ```
 
@@ -100,24 +99,24 @@ and adding an actual configuration object as a dynamic field. Using this _anchor
 configuration can be changed with package upgrades while keeping the same base object signature.
 
 ```move
-module book::versioned_config {
-    use sui::vec_map::VecMap;
-    use std::string::String;
+module book::versioned_config;
 
-    /// The base object
-    public struct Config has key {
-        id: UID,
-        version: u16
-    }
+use sui::vec_map::VecMap;
+use std::string::String;
 
-    /// The actual configuration
-    public struct ConfigV1 has store {
-        data: Bag,
-        metadata: VecMap<String, String>
-    }
-
-    // ...
+/// The base object
+public struct Config has key {
+    id: UID,
+    version: u16
 }
+
+/// The actual configuration
+public struct ConfigV1 has store {
+    data: Bag,
+    metadata: VecMap<String, String>
+}
+
+// ...
 ```
 
 ## Modular architecture

--- a/book/src/introduction.md
+++ b/book/src/introduction.md
@@ -4,7 +4,7 @@ Welcome to The Move Book, a book about the Move language.
 
 > [The Move Reference](/reference) focuses on the language itself, while this book is structured as a learning path,
 > starting with the basics and moving on to more advanced topics. The link to The Move Reference is always
-> available at the top of the page, similarly, there's a link to the book at the top of the
+> available at the top of the page. Similarly, there's a link to The Move Book at the top of the
 > reference page.
 
 <!--

--- a/book/src/introduction.md
+++ b/book/src/introduction.md
@@ -2,7 +2,6 @@
 
 Welcome to The Move Book, a book about the Move language.
 
-> If you're looking for The Move Reference, it is available here: [The Move Reference](/reference).
 > The reference focuses on the language itself, while this book is structured as a learning path,
 > starting with the basics and moving on to more advanced topics. The link to reference is always
 > available at the top of the page, similarly, there's a link to the book at the top of the

--- a/book/src/introduction.md
+++ b/book/src/introduction.md
@@ -2,7 +2,7 @@
 
 Welcome to The Move Book, a book about the Move language.
 
-> The reference focuses on the language itself, while this book is structured as a learning path,
+> [The Move Reference](/reference) focuses on the language itself, while this book is structured as a learning path,
 > starting with the basics and moving on to more advanced topics. The link to The Move Reference is always
 > available at the top of the page, similarly, there's a link to the book at the top of the
 > reference page.

--- a/book/src/introduction.md
+++ b/book/src/introduction.md
@@ -3,7 +3,7 @@
 Welcome to The Move Book, a book about the Move language.
 
 > The reference focuses on the language itself, while this book is structured as a learning path,
-> starting with the basics and moving on to more advanced topics. The link to reference is always
+> starting with the basics and moving on to more advanced topics. The link to The Move Reference is always
 > available at the top of the page, similarly, there's a link to the book at the top of the
 > reference page.
 

--- a/book/src/introduction.md
+++ b/book/src/introduction.md
@@ -1,6 +1,6 @@
 # Introduction
 
-Welcome to The Move Book, a book about Move language.
+Welcome to The Move Book, a book about the Move language.
 
 > If you're looking for The Move Reference, it is available here: [The Move Reference](/reference).
 > The reference focuses on the language itself, while this book is structured as a learning path,

--- a/book/src/introduction.md
+++ b/book/src/introduction.md
@@ -2,7 +2,11 @@
 
 Welcome to The Move Book, a book about Move language.
 
-> If you're looking for The Move Reference, it is available here: [The Move Reference](/reference). The reference focuses on the language itself, while this book is structured as a learning path, starting with the basics and moving on to more advanced topics. The link to reference is always available at the top of the page, similarly, there's a link to the book at the top of the reference page.
+> If you're looking for The Move Reference, it is available here: [The Move Reference](/reference).
+> The reference focuses on the language itself, while this book is structured as a learning path,
+> starting with the basics and moving on to more advanced topics. The link to reference is always
+> available at the top of the page, similarly, there's a link to the book at the top of the
+> reference page.
 
 <!--
 

--- a/book/src/move-basics/abilities-introduction.md
+++ b/book/src/move-basics/abilities-introduction.md
@@ -33,7 +33,7 @@ struct VeryAble has copy, drop {
 
 A quick overview of the abilities:
 
-> All of the built-in types except [references](references.md) have `copy`, `drop` and `store`
+> All of the built-in types except [references](references.md) have `copy`, `drop`, and `store`
 > abilities. References have `copy` and `drop`.
 
 - `copy` - allows the struct to be _copied_. Explained in the [Ability: Copy](./copy-ability.md)

--- a/book/src/move-basics/abilities-introduction.md
+++ b/book/src/move-basics/abilities-introduction.md
@@ -22,7 +22,7 @@ The abilities are separated by commas. Move supports 4 abilities: `copy`, `drop`
 
 ```move
 /// This struct has the `copy` and `drop` abilities.
-struct VeryAble has copy, drop {
+public struct VeryAble has copy, drop {
     // field: Type1,
     // field2: Type2,
     // ...

--- a/book/src/move-basics/abilities-introduction.md
+++ b/book/src/move-basics/abilities-introduction.md
@@ -51,7 +51,7 @@ in the following chapters and give proper context on how to use them.
 ## No Abilities
 
 A struct without abilities cannot be discarded, copied, or stored in storage. We call such a struct
-a _Hot Potato_. It is a joke, but it is also a good way to remember that a struct without abilities
+a _Hot Potato_. A lighthearted name, but it is a good way to remember that a struct without abilities
 is like a hot potato - it can only be passed around and requires special handling. The Hot Potato is
 one of the most powerful patterns in Move, and we go into more detail about it in the
 [Hot Potato Pattern](./../programmability/hot-potato-pattern.md) chapter.

--- a/book/src/move-basics/abilities-introduction.md
+++ b/book/src/move-basics/abilities-introduction.md
@@ -14,7 +14,7 @@ compile. This is default behavior of a struct without _abilities_.
 Abilities are a way to allow certain behaviors for a type. They are a part of the struct declaration
 and define which behaviors are allowed for the instances of the struct.
 
-## Abilities syntax
+## Abilities Syntax
 
 Abilities are set in the struct definition using the `has` keyword followed by a list of abilities.
 The abilities are separated by commas. Move supports 4 abilities: `copy`, `drop`, `key`, and
@@ -33,8 +33,8 @@ struct VeryAble has copy, drop {
 
 A quick overview of the abilities:
 
-> All of the built-in types except [references](references.md) have `copy`, `drop` and `store` abilities.
-> References have `copy` and `drop`.
+> All of the built-in types except [references](references.md) have `copy`, `drop` and `store`
+> abilities. References have `copy` and `drop`.
 
 - `copy` - allows the struct to be _copied_. Explained in the [Ability: Copy](./copy-ability.md)
   chapter.
@@ -42,20 +42,20 @@ A quick overview of the abilities:
   [Ability: Drop](./drop-ability.md) chapter.
 - `key` - allows the struct to be used as a _key_ in a storage. Explained in the
   [Ability: Key](./../storage/key-ability.md) chapter.
-- `store` - allows the struct to be _stored_ in structs that have the _key_ ability. Explained in the
-  [Ability: Store](./../storage/store-ability.md) chapter.
+- `store` - allows the struct to be _stored_ in structs that have the _key_ ability. Explained in
+  the [Ability: Store](./../storage/store-ability.md) chapter.
 
-While it is important to briefly mention them here, we will go into more detail about each ability in the following
-chapters and give proper context on how to use them.
+While it is important to briefly mention them here, we will go into more detail about each ability
+in the following chapters and give proper context on how to use them.
 
-## No abilities
+## No Abilities
 
-A struct without abilities cannot be discarded, copied, or stored in storage. We call such a
-struct a _Hot Potato_. It is a joke, but it is also a good way to remember that a struct without
-abilities is like a hot potato - it can only be passed around and requires special handling. The Hot
-Potato is one of the most powerful patterns in Move, and we go into more detail about it in the
+A struct without abilities cannot be discarded, copied, or stored in storage. We call such a struct
+a _Hot Potato_. It is a joke, but it is also a good way to remember that a struct without abilities
+is like a hot potato - it can only be passed around and requires special handling. The Hot Potato is
+one of the most powerful patterns in Move, and we go into more detail about it in the
 [Hot Potato Pattern](./../programmability/hot-potato-pattern.md) chapter.
 
-## Further reading
+## Further Reading
 
 - [Type Abilities](/reference/abilities.html) in the Move Reference.

--- a/book/src/move-basics/address.md
+++ b/book/src/move-basics/address.md
@@ -17,9 +17,10 @@ Links:
     - your first move
 
  -->
+
 Move uses a special type called [address](./../concepts/address.md) to represent addresses. It is a
-32-byte value that can represent any address on the blockchain. Addresses can be written in two forms:
-hexadecimal addresses prefixed with 0x and named addresses.
+32-byte value that can represent any address on the blockchain. Addresses can be written in two
+forms: hexadecimal addresses prefixed with 0x and named addresses.
 
 ```move
 {{#include ../../../packages/samples/sources/move-basics/address.move:address_literal}}
@@ -54,7 +55,7 @@ Example: Convert an address into a string.
 {{#include ../../../packages/samples/sources/move-basics/address.move:to_string}}
 ```
 
-## Further reading
+## Further Reading
 
 - [Address](/reference/primitive-types/address.html) in the Move Reference.
-- [sui::address module](https://docs.sui.io/references/framework/sui/address)
+- [sui::address](https://docs.sui.io/references/framework/sui/address) module documentation.

--- a/book/src/move-basics/assert-and-abort.md
+++ b/book/src/move-basics/assert-and-abort.md
@@ -20,10 +20,10 @@ Links:
     - constants (previous section)
  -->
 
-A transaction can either succeed or fail. Successful execution applies all changes made to
-objects and on-chain data, and the transaction is committed to the blockchain. Alternatively, if a
-transaction aborts, changes are not applied. Use the `abort` keyword to abort a transaction
-and revert any changes that were made.
+A transaction can either succeed or fail. Successful execution applies all changes made to objects
+and on-chain data, and the transaction is committed to the blockchain. Alternatively, if a
+transaction aborts, changes are not applied. Use the `abort` keyword to abort a transaction and
+revert any changes that were made.
 
 > It is important to note that there is no catch mechanism in Move. If a transaction aborts, the
 > changes made so far are reverted, and the transaction is considered failed.
@@ -56,9 +56,9 @@ an `if` expression + `abort`. The `code` argument is optional, but has to be a `
 
 To make error codes more descriptive, it is a good practice to define
 [error constants](./constants.md). Error constants are defined as `const` declarations and are
-usually prefixed with `E` followed by a camel case name. Error constants are similar to other constants
-and do not have any special handling. However, they are commonly used to improve code readability and
-make abort scenarios easier to understand.
+usually prefixed with `E` followed by a camel case name. Error constants are similar to other
+constants and do not have any special handling. However, they are commonly used to improve code
+readability and make abort scenarios easier to understand.
 
 ```move
 {{#include ../../../packages/samples/sources/move-basics/assert-and-abort.move:error_const}}
@@ -74,7 +74,7 @@ message.
 {{#include ../../../packages/samples/sources/move-basics/assert-and-abort.move:error_attribute}}
 ```
 
-## Further reading
+## Further Reading
 
 - [Abort and Assert](/reference/abort-and-assert.html) in the Move Reference.
 - We suggest reading the [Better Error Handling](./../guides/better-error-handling.md) guide to

--- a/book/src/move-basics/comments.md
+++ b/book/src/move-basics/comments.md
@@ -13,12 +13,11 @@ Notes:
  -->
 
 Comments are a way to add notes or document your code. They are ignored by the compiler and don't
-result in Move bytecode. You can use comments to explain what your code does, add notes to
-yourself or other developers, temporarily remove a part of your code, or generate
-documentation. There are three types of comments in Move: line comments, block comments, and doc
-comments.
+result in Move bytecode. You can use comments to explain what your code does, add notes to yourself
+or other developers, temporarily remove a part of your code, or generate documentation. There are
+three types of comments in Move: line comments, block comments, and doc comments.
 
-## Line comment
+## Line Comment
 
 You can use a double slash `//` to comment out the rest of the line. Everything after `//` will be
 ignored by the compiler.
@@ -27,7 +26,7 @@ ignored by the compiler.
 {{#include ../../../packages/samples/sources/move-basics/comments-line.move:main}}
 ```
 
-## Block comment
+## Block Comment
 
 Block comments are used to comment out a block of code. They start with `/*` and end with `*/`.
 Everything between `/*` and `*/` will be ignored by the compiler. You can use block comments to
@@ -39,11 +38,11 @@ comment out a single line or multiple lines. You can even use them to comment ou
 
 This example is a bit extreme, but it shows all the ways that you can use block comments.
 
-## Doc comment
+## Doc Comment
 
 Documentation comments are special comments that are used to generate documentation for your code.
-They are similar to block comments but start with three slashes `///` and are placed before
-the definition of the item they document.
+They are similar to block comments but start with three slashes `///` and are placed before the
+definition of the item they document.
 
 ```Move
 {{#include ../../../packages/samples/sources/move-basics/comments-doc.move:main}}
@@ -51,7 +50,7 @@ the definition of the item they document.
 
 ## Whitespace
 
-Unlike some languages, whitespace (spaces, tabs, and newlines) have no impact
-on the meaning of the program.
+Unlike some languages, whitespace (spaces, tabs, and newlines) have no impact on the meaning of the
+program.
 
 <!-- TODO: docgen, which members are in the documentation -->

--- a/book/src/move-basics/constants.md
+++ b/book/src/move-basics/constants.md
@@ -40,8 +40,8 @@ makes constants stand out from other identifiers in the code. An exception is ma
 
 ## Constants are Immutable
 
-Constants can't be changed and assigned new values. As part of the package bytecode, they
-are inherently immutable.
+Constants can't be changed and assigned new values. As part of the package bytecode, they are
+inherently immutable.
 
 ```move
 module book::immutable_constants;

--- a/book/src/move-basics/control-flow.md
+++ b/book/src/move-basics/control-flow.md
@@ -43,9 +43,9 @@ if (<bool_expression>) <expression> else <expression>;
 ```
 
 Just like any other expression, `if` requires a semicolon if there are other expressions following
-it. The `else` keyword is optional, except when the resulting value is assigned to a variable, as all 
-branches must return a value to ensure type safety. Let’s examine how an `if` expression works in Move
-with the following example:
+it. The `else` keyword is optional, except when the resulting value is assigned to a variable, as
+all branches must return a value to ensure type safety. Let’s examine how an `if` expression works
+in Move with the following example:
 
 ```move
 {{#include ../../../packages/samples/sources/move-basics/control-flow.move:if_condition}}
@@ -57,11 +57,18 @@ Let's see how we can use `if` and `else` to assign a value to a variable:
 {{#include ../../../packages/samples/sources/move-basics/control-flow.move:if_else}}
 ```
 
-In this example, the value of the `if` expression is assigned to the variable `y`. If `x` is greater than 0, `y` is assigned the value 1; otherwise, it is assigned 0. The `else` block is required because both branches of the `if` expression must return a value of the same type. Omitting the `else` block would result in a compiler error, as it ensures all possible branches are accounted for and type safety is maintained.
+In this example, the value of the `if` expression is assigned to the variable `y`. If `x` is greater
+than 0, `y` is assigned the value 1; otherwise, it is assigned 0. The `else` block is required
+because both branches of the `if` expression must return a value of the same type. Omitting the
+`else` block would result in a compiler error, as it ensures all possible branches are accounted for
+and type safety is maintained.
 
 <!-- TODO: add an error -->
 
-Conditional expressions are among the most important control flow statements in Move. They evaluate user-provided input or stored data to make decisions. One key use case is in the [`assert!` macro](./assert-and-abort.md), which checks if a condition is true and aborts execution if it is not. We’ll explore this in detail shortly.
+Conditional expressions are among the most important control flow statements in Move. They evaluate
+user-provided input or stored data to make decisions. One key use case is in the
+[`assert!` macro](./assert-and-abort.md), which checks if a condition is true and aborts execution
+if it is not. We’ll explore this in detail shortly.
 
 ## Repeating Statements with Loops
 
@@ -70,14 +77,16 @@ Loops are used to execute a block of code multiple times. Move has two built-in 
 the number of iterations is known in advance, and `loop` is used when the number of iterations is
 not known in advance or there are multiple exit points.
 
-Loops are useful for working with collections, such as vectors, or for repeating a block of code until a specific condition is met. However, take care to avoid infinite loops, which can exhaust gas limits and cause the transaction to abort.
+Loops are useful for working with collections, such as vectors, or for repeating a block of code
+until a specific condition is met. However, take care to avoid infinite loops, which can exhaust gas
+limits and cause the transaction to abort.
 
-## The `while` loop
+## The `while` Loop
 
-The `while` statement executes a block of code repeatedly as long as a boolean expression evaluates to true.
-Just like we've seen with `if`, the boolean expression is evaluated before each iteration of the
-loop. Additionally, like conditional statements, the `while` loop is an expression and requires a semicolon
-if there are other expressions following it.
+The `while` statement executes a block of code repeatedly as long as a boolean expression evaluates
+to true. Just like we've seen with `if`, the boolean expression is evaluated before each iteration
+of the loop. Additionally, like conditional statements, the `while` loop is an expression and
+requires a semicolon if there are other expressions following it.
 
 The syntax for the `while` loop is:
 
@@ -94,14 +103,15 @@ Here is an example of a `while` loop with a very simple condition:
 ## Infinite `loop`
 
 Now let's imagine a scenario where the boolean expression is always `true`. For example, if we
-literally passed `true` to the `while` condition. This is similar to how the `loop` statement functions, 
-except that `while` evaluates a condition.
+literally passed `true` to the `while` condition. This is similar to how the `loop` statement
+functions, except that `while` evaluates a condition.
 
 ```move
 {{#include ../../../packages/samples/sources/move-basics/control-flow.move:infinite_while}}
 ```
 
-An infinite `while` loop, or a `while` loop with an always `true` condition, is equivalent to a `loop`. The syntax for creating a `loop` is straightforward:
+An infinite `while` loop, or a `while` loop with an always `true` condition, is equivalent to a
+`loop`. The syntax for creating a `loop` is straightforward:
 
 ```move
 loop { <expressions>; };
@@ -113,9 +123,11 @@ Let's rewrite the previous example using `loop` instead of `while`:
 {{#include ../../../packages/samples/sources/move-basics/control-flow.move:infinite_loop}}
 ```
 
-<!-- TODO: that's a weak point lmao -->
-
-Infinite loops are rarely practical in Move, as every operation consumes gas, and an infinite loop will inevitably lead to gas exhaustion. If you find yourself using a loop, consider whether there might be a better approach, as many use cases can be handled more efficiently with other control flow structures. That said, `loop` might be useful when combined with `break` and `continue` statements to create controlled and flexible looping behavior.
+Infinite loops are rarely practical in Move, as every operation consumes gas, and an infinite loop
+will inevitably lead to gas exhaustion. If you find yourself using a loop, consider whether there
+might be a better approach, as many use cases can be handled more efficiently with other control
+flow structures. That said, `loop` might be useful when combined with `break` and `continue`
+statements to create controlled and flexible looping behavior.
 
 ## Exiting a Loop Early
 
@@ -139,7 +151,8 @@ looks and behaves more like a `while` loop:
 ```
 
 Almost identical to the `while` loop, right? The `break` statement is used to exit the loop when `x`
-is 5. If we remove the `break` statement, the loop will run forever, just like in the previous example.
+is 5. If we remove the `break` statement, the loop will run forever, just like in the previous
+example.
 
 ## Skipping an Iteration
 
@@ -180,3 +193,7 @@ Here is an example of a function that returns a value when a certain condition i
 Unlike in many other languages, the `return` statement is not required for the last expression in a
 function. The last expression in a function block is automatically returned. However, the `return`
 statement is useful when we want to exit a function early if a certain condition is met.
+
+## Further Reading
+
+- [Control Flow](/reference/control-flow.html) chapter in the Move Reference.

--- a/book/src/move-basics/control-flow.md
+++ b/book/src/move-basics/control-flow.md
@@ -83,7 +83,7 @@ limits and cause the transaction to abort.
 
 ## The `while` Loop
 
-The `while` statement executes a block of code repeatedly as long as a boolean expression evaluates
+The `while` statement executes a block of code repeatedly as long as the associated boolean expression evaluates
 to true. Just like we've seen with `if`, the boolean expression is evaluated before each iteration
 of the loop. Additionally, like conditional statements, the `while` loop is an expression and
 requires a semicolon if there are other expressions following it.

--- a/book/src/move-basics/copy-ability.md
+++ b/book/src/move-basics/copy-ability.md
@@ -2,9 +2,9 @@
 
 In Move, the _copy_ ability on a type indicates that the instance or the value of the type can be
 copied, or duplicated. While this behavior is provided by default when working with numbers or other
-primitive types, it is not the default for custom types. Move is designed to express digital
-assets and resources, and controlling the ability to duplicate resources is a key principle of the
-resource model. However, the Move type system allows you to add the _copy_ ability to custom types:
+primitive types, it is not the default for custom types. Move is designed to express digital assets
+and resources, and controlling the ability to duplicate resources is a key principle of the resource
+model. However, the Move type system allows you to add the _copy_ ability to custom types:
 
 ```move
 {{#include ../../../packages/samples/sources/move-basics/copy-ability.move:copyable}}
@@ -22,16 +22,16 @@ dereference operator. If `Copyable` did not have the _copy_ ability, the code wo
 the Move compiler would raise an error.
 
 > Note: In Move, destructuring with empty brackets is often used to consume unused variables,
-> especially for types without the drop ability. This prevents compiler errors from values
-> going out of scope without explicit use. Also, Move requires the type name in destructuring
-> (e.g., `Copyable` in `let Copyable {} = a;`) because it enforces strict typing and ownership rules.
+> especially for types without the drop ability. This prevents compiler errors from values going out
+> of scope without explicit use. Also, Move requires the type name in destructuring (e.g.,
+> `Copyable` in `let Copyable {} = a;`) because it enforces strict typing and ownership rules.
 
 ## Copying and Drop
 
 The `copy` ability is closely related to the [`drop` ability](./drop-ability.md). If a type has the
-_copy_ ability, it is very likely that it should have `drop` too. This is because the _drop_ ability is
-required to clean up resources when the instance is no longer needed. If a type only has _copy_,
-managing its instances gets more complicated, as the instances must be explicitly used or consumed. 
+_copy_ ability, it is very likely that it should have `drop` too. This is because the _drop_ ability
+is required to clean up resources when the instance is no longer needed. If a type only has _copy_,
+managing its instances gets more complicated, as the instances must be explicitly used or consumed.
 
 ```move
 {{#include ../../../packages/samples/sources/move-basics/copy-ability.move:copy_drop}}
@@ -56,6 +56,6 @@ All of the types defined in the standard library have the `copy` ability as well
 - [String](./../move-basics/string.md)
 - [TypeName](./../move-basics/type-reflection.md#typename)
 
-## Further reading
+## Further Reading
 
 - [Type Abilities](/reference/abilities.html) in the Move Reference.

--- a/book/src/move-basics/drop-ability.md
+++ b/book/src/move-basics/drop-ability.md
@@ -55,9 +55,7 @@ feature of Move's type system is the ability to not have `drop`. This ensures th
 properly handled and not ignored.
 
 A struct with a single `drop` ability is called a _Witness_. We explain the concept of a _Witness_
-in the
-[Witness and Abstract Implementation](./../programmability/witness-pattern.md)
-section.
+in the [Witness and Abstract Implementation](./../programmability/witness-pattern.md) section.
 
 ## Types with the `drop` Ability
 
@@ -74,6 +72,6 @@ All of the types defined in the standard library have the `drop` ability as well
 - [`String`](./../move-basics/string.md)
 - [`TypeName`](./../move-basics/type-reflection.md#typename)
 
-## Further reading
+## Further Reading
 
 - [Type Abilities](/reference/abilities.html) in the Move Reference.

--- a/book/src/move-basics/enum-and-match.md
+++ b/book/src/move-basics/enum-and-match.md
@@ -37,7 +37,7 @@ the type, the variant, and the values for any fields defined in that variant.
 Depending on the use case, you may want to provide public constructors, or instantiate enums
 internally as a part of application logic.
 
-## Using in type definitions
+## Using in Type Definitions
 
 The biggest benefit of using enums is the ability to represent varying data structures under a
 single type. To demonstrate this, let’s define a struct that contains a vector of `Segment` values:
@@ -78,7 +78,7 @@ for a specific variant of the `Segment` enum. If `s` matches `Segment::Empty`, t
 For variants with fields, we need to bind the inner structure to local variables (even if we don’t
 use them, marking unused values with `_` to avoid compiler warnings).
 
-### Trick #1 - _any_ condition
+### Trick #1 - _any_ Condition
 
 The Move compiler infers the type of the value used in a `match` expression and ensures that the
 _match arms_ are exhaustive – that is, all possible variants or values must be covered.
@@ -101,7 +101,7 @@ Similarly, we can use the same approach to define `is_special` and `is_string`:
 {{#include ../../../packages/samples/sources/move-basics/enum-and-match.move:accessors}}
 ```
 
-### Trick #2 - `try_into` helpers
+### Trick #2 - `try_into` Helpers
 
 With the addition of `is_variant` functions, we enabled external modules to check which variant an
 enum instance represents. However, this is often not enough – external code still cannot access the
@@ -116,7 +116,7 @@ value and return an `Option` containing the inner contents if the `match` succee
 
 This pattern safely exposes internal data in a controlled way, avoiding abort.
 
-### Trick #3 - Matching on primitive values
+### Trick #3 - Matching on Primitive Values
 
 The `match` expression in Move can be used with values of any type – enums, structs, or primitives.
 To demonstrate this, let’s implement a `to_string` function that creates a new `String` from a
@@ -132,7 +132,7 @@ This function demonstrates two key things:
 - Nested `match` expressions can be used for deeper logic branching.
 - Wildcards are essential for covering all possible values in primitive types like `u8`.
 
-## The final test
+## The Final Test
 
 Now we can finalize the test we started before using the features we have added. Let's create a
 scenario where we build enums into a vector.
@@ -159,7 +159,7 @@ To learn more about enums and pattern matching, refer to the resources listed in
   - Can return values and be used in expressions;
 - Common patterns for enums include `is_variant` checks and `try_into` helper functions.
 
-## Further reading
+## Further Reading
 
 - [Enums](/reference/enums.html) in the Move Reference
 - [Pattern Matching](/reference/control-flow/pattern-matching.html) in the Move Reference

--- a/book/src/move-basics/enum-and-match.md
+++ b/book/src/move-basics/enum-and-match.md
@@ -58,7 +58,7 @@ because we need to make sure that the value we are trying to access is the right
 offers _pattern matching_ syntax.
 
 > This chapter doesn't intend to cover all the features of pattern matching in Move. Refer to the
-> [Pattern Matching](/reference/pattern-matching.html) section in the Move Reference.
+> [Pattern Matching](/reference/control-flow/pattern-matching.html) section in the Move Reference.
 
 Pattern matching allows conditioning the logic based on the _pattern_ of the value. It is performed
 using the `match` expression, followed by the matched value in parenthesis and the block of _match
@@ -162,4 +162,4 @@ To learn more about enums and pattern matching, refer to the resources listed in
 ## Further reading
 
 - [Enums](/reference/enums.html) in the Move Reference
-- [Pattern Matching](/reference/pattern-matching.html) in the Move Reference
+- [Pattern Matching](/reference/control-flow/pattern-matching.html) in the Move Reference

--- a/book/src/move-basics/enum-and-match.md
+++ b/book/src/move-basics/enum-and-match.md
@@ -12,23 +12,7 @@ named fields. Enum must have at least one variant. The structure of each variant
 and the total number of variants can be relatively large - up to 100.
 
 ```move
-module book::segment;
-
-use std::string::String;
-
-/// `Segment` enum definition.
-/// Represents options for segments of a string.
-public enum Segment has drop, copy {
-    /// Empty variant, no value
-    Empty,
-    /// Variant with a value (positional style)
-    String(String),
-    /// Variant with named fields
-    Special {
-        content: vector<u8>,
-        encoding: u8, // Encoding tag
-    }
-}
+{{#include ../../../packages/samples/sources/move-basics/enum-and-match.move:definition}}
 ```
 
 In the code sample above we defined a public `Segment` enum, which has the `drop` and `copy`
@@ -47,19 +31,7 @@ constructed, read, and unpacked within the same module.
 the type, the variant, and the values for any fields defined in that variant.
 
 ```move
-/// Constructs an `Empty` segment.
-public fun new_empty(): Segment { Segment::Empty }
-
-/// Constructs a `String` segment with the `str` value.
-public fun new_string(str: String): Segment { Segment::String(str) }
-
-/// Constructs a `Special` segment with the `content` and `encoding` values.
-public fun new_special(content: vector<u8>, encoding: u8): Segment {
-    Segment::Special {
-        content,
-        encoding,
-    }
-}
+{{#include ../../../packages/samples/sources/move-basics/enum-and-match.move:constructors}}
 ```
 
 Depending on the use case, you may want to provide public constructors, or instantiate enums
@@ -71,19 +43,7 @@ The biggest benefit of using enums is the ability to represent varying data stru
 single type. To demonstrate this, let’s define a struct that contains a vector of `Segment` values:
 
 ```move
-/// A struct to demonstrate enum capabilities.
-public struct Segments(vector<Segment>) has drop, copy;
-
-#[test]
-fun test_segments() {
-    let _ = Segments(vector[
-        Segment::Empty,
-        Segment::String(b"hello".to_string()),
-        Segment::Special { content: b" ", encoding: 0 },
-        Segment::String(b"move".to_string()),
-        Segment::Special { content: b"21", encoding: 1 },
-    ]);
-}
+{{#include ../../../packages/samples/sources/move-basics/enum-and-match.move:struct}}
 ```
 
 All variants of the Segment enum share the same type – `Segment` – which allows us to create a
@@ -108,15 +68,7 @@ Let's extend our example by adding a set of `is_variant`-like functions, so exte
 check the variant. Starting with `is_empty`.
 
 ```move
-/// Whether this it's an `Empty` segment.
-public fun is_empty(s: &Segment): bool {
-    // Match is an expression, hence its value will be the return value of the function
-    match (s) {
-        Segment::Empty => true,
-        Segment::String(_str) => false,
-        Segment::Special { content: _, encoding: _ } => false
-    }
-}
+{{#include ../../../packages/samples/sources/move-basics/enum-and-match.move:is_empty}}
 ```
 
 The `match` keyword begins the expression, and `s` is the value being tested. Each match arm checks
@@ -140,32 +92,13 @@ variants with a wildcard:
 
 ```move
 public fun is_empty(s: &Segment): bool {
-    match (s) {
-        Segment::Empty => true,
-        _ => false, // Anything else returns `false`
-    }
-}
+{{#include ../../../packages/samples/sources/move-basics/enum-and-match.move:is_empty_2}}
 ```
 
 Similarly, we can use the same approach to define `is_special` and `is_string`:
 
 ```move
-/// Whether it's a `Special` segment.
-public fun is_special(s: &Segment): bool {
-    match (s) {
-        // hint: the `..` ignores inner fields
-        Segment::Special { .. } => true,
-        _ => false,
-    }
-}
-
-/// Whether it's a `String` segment.
-public fun is_string(s: &Segment): bool {
-    match (s) {
-        Segment::String(_) => true,
-        _ => false,
-    }
-}
+{{#include ../../../packages/samples/sources/move-basics/enum-and-match.move:accessors}}
 ```
 
 ### Trick #2 - `try_into` helpers
@@ -178,13 +111,7 @@ A common pattern for addressing this is to define `try_into` functions. These fu
 value and return an `Option` containing the inner contents if the `match` succeeds.
 
 ```move
-/// Returns `Some(String)` if the `Segment` is `String`, `None` otherwise.
-public fun try_into_inner_string(s: Segment): Option<String> {
-    match (s) {
-        Segment::String(str) => option::some(str),
-        _ => option::none()
-    }
-}
+{{#include ../../../packages/samples/sources/move-basics/enum-and-match.move:try_into_inner_string}}
 ```
 
 This pattern safely exposes internal data in a controlled way, avoiding abort.
@@ -197,27 +124,7 @@ To demonstrate this, let’s implement a `to_string` function that creates a new
 how to decode the content.
 
 ```move
-/// Return a `String` representation of a segment.
-public fun to_string(s: &Segment): String {
-    match (*s) {
-        // Return an empty string.
-        Segment::Empty => b"".to_string(),
-        // Return the inner string.
-        Segment::String(str) => str,
-        // Return the decoded contents based on the encoding.
-        Segment::Special { content, encoding } => {
-            // perform a match on the encoding, we only support 0 - utf8, 1 - hex
-            match (encoding) {
-                // Plain encoding, return content.
-                0 => content.to_string(),
-                // HEX encoding, decode and return.
-                1 => sui::hex::decode(content).to_string(),
-                // We have to provide a wildcard pattern, because values of `u8` are 0-255.
-                _ => abort
-            }
-        }
-    }
-}
+{{#include ../../../packages/samples/sources/move-basics/enum-and-match.move:to_string}}
 ```
 
 This function demonstrates two key things:
@@ -231,35 +138,7 @@ Now we can finalize the test we started before using the features we have added.
 scenario where we build enums into a vector.
 
 ```move
-// Note, that the module has changed!
-module book::segment_tests;
-
-use book::segment;
-use std::unit_test::assert_eq;
-
-#[test]
-fun test_full_enum_cycle() {
-    // Create a vector of different Segment variants.
-    let segments = vector[
-        segment::new_empty(),
-        segment::new_string(b"hello".to_string()),
-        segment::new_special(b" ", 0), // plaintext
-        segment::new_string(b"move".to_string()),
-        segment::new_special(b"21", 1), // hex
-    ];
-
-    // Aggregate all segments into the final string using `vector::fold!` macro.
-    let result = segments.fold!(b"".to_string(), |mut acc, segment| {
-        // do not append empty, only `Special` and `String`
-        if (!segment.is_empty()) {
-            acc.append(segment.to_string());
-        };
-        acc
-    });
-
-    // Check that the result is a what's expected.
-    assert_eq!(result, b"hello move!".to_string());
-}
+{{#include ../../../packages/samples/sources/move-basics/enum-and-match-2.move:enum_test}}
 ```
 
 This test demonstrates the full enum workflow: instantiating different variants, using public

--- a/book/src/move-basics/expression.md
+++ b/book/src/move-basics/expression.md
@@ -1,18 +1,18 @@
 # Expression
 
 In programming languages, an expression is a unit of code that returns a value. In Move, almost
-everything is an expression, with the sole exception of the `let` statement, which is a declaration. In
-this section, we cover the types of expressions and introduce the concept of scope.
+everything is an expression, with the sole exception of the `let` statement, which is a declaration.
+In this section, we cover the types of expressions and introduce the concept of scope.
 
 > Expressions are sequenced with semicolons `;`. If there's "no expression" after the semicolon, the
 > compiler will insert a `unit ()`, which represents an empty expression.
 
 ## Literals
 
-In the [Primitive Types](./primitive-types.md) section, we introduced the basic types of Move. And
-to illustrate them, we used literals. A literal is a notation for representing a fixed value in 
-source code. Literals can be used to initialize variables or directly pass fixed values as arguments to 
-functions. Move has the following literals:
+In the [Primitive types](./primitive-types.md) section, we introduced the basic types of Move. And
+to illustrate them, we used literals. A literal is a notation for representing a fixed value in
+source code. Literals can be used to initialize variables or directly pass fixed values as arguments
+to functions. Move has the following literals:
 
 - Boolean values: `true` and `false`
 - Integer values: `0`, `1`, `123123`
@@ -26,7 +26,7 @@ functions. Move has the following literals:
 
 ## Operators
 
-Arithmetic, logical, and bitwise operators are used to perform operations on values. Since these 
+Arithmetic, logical, and bitwise operators are used to perform operations on values. Since these
 operations produce values, they are considered expressions.
 
 ```move
@@ -35,9 +35,9 @@ operations produce values, they are considered expressions.
 
 ## Blocks
 
-A block is a sequence of statements and expressions enclosed in curly braces `{}`. It returns the value of 
-the last expression in the block (note that this final expression must not have an ending semicolon).
-A block is an expression, so it can be used anywhere an expression is expected. 
+A block is a sequence of statements and expressions enclosed in curly braces `{}`. It returns the
+value of the last expression in the block (note that this final expression must not have an ending
+semicolon). A block is an expression, so it can be used anywhere an expression is expected.
 
 ```move
 {{#include ../../../packages/samples/sources/move-basics/expression.move:block}}
@@ -45,10 +45,10 @@ A block is an expression, so it can be used anywhere an expression is expected.
 
 ## Function Calls
 
-We go into detail about functions in the [Functions](./functions.md) section. However, we have already
-used function calls in previous sections, so it's worth mentioning them here. A function call is
-an expression that calls a function and returns the value of the last expression in the function
-body, provided the last expression does not have a terminating semi-colon.
+We go into detail about functions in the [Functions](./functions.md) section. However, we have
+already used function calls in previous sections, so it's worth mentioning them here. A function
+call is an expression that calls a function and returns the value of the last expression in the
+function body, provided the last expression does not have a terminating semi-colon.
 
 ```move
 {{#include ../../../packages/samples/sources/move-basics/expression.move:fun_call}}

--- a/book/src/move-basics/function.md
+++ b/book/src/move-basics/function.md
@@ -10,21 +10,21 @@ and can only be accessed from within the module.
 {{#include ../../../packages/samples/sources/move-basics/function.move:math}}
 ```
 
-In this example, we define a function `add` that takes two arguments of type `u64` and returns their sum.
-The `test_add` function, located in the same module, is a test function that calls `add`. The test uses the
-`assert!` macro to compare the result of `add` with the expected value. If the condition inside `assert!` evaluates
-to false, the execution is aborted automatically.
+In this example, we define a function `add` that takes two arguments of type `u64` and returns their
+sum. The `test_add` function, located in the same module, is a test function that calls `add`. The
+test uses the `assert!` macro to compare the result of `add` with the expected value. If the
+condition inside `assert!` evaluates to false, the execution is aborted automatically.
 
 ## Function declaration
 
-> In Move, functions are typically named using the `snake_case` convention. This means function names
-> should be all lowercase, with words separated by underscores. Examples include `do_something`, `add`,
-> `get_balance`, `is_authorized`, and so on.
+> In Move, functions are typically named using the `snake_case` convention. This means function
+> names should be all lowercase, with words separated by underscores. Examples include
+> `do_something`, `add`, `get_balance`, `is_authorized`, and so on.
 
 A function is declared with the `fun` keyword followed by the function name (a valid Move
 identifier), a list of arguments in parentheses, and a return type. The function body is a block of
-code that contains a sequence of statements and expressions. The last expression the function
-body is the return value of the function.
+code that contains a sequence of statements and expressions. The last expression the function body
+is the return value of the function.
 
 ```move
 {{#include ../../../packages/samples/sources/move-basics/function.move:return_nothing}}
@@ -32,10 +32,11 @@ body is the return value of the function.
 
 ## Accessing functions
 
-Just like other module members, functions can be imported and accessed using a path. The path consists
-of the module path and the function name, separated by ::. For example, if you have a function named
-`add` in the `math` module within the `book` package, its full path would be `book::math::add`. If the module
-has already been imported, you can access it directly as `math::add` as in the following example:
+Just like other module members, functions can be imported and accessed using a path. The path
+consists of the module path and the function name, separated by ::. For example, if you have a
+function named `add` in the `math` module within the `book` package, its full path would be
+`book::math::add`. If the module has already been imported, you can access it directly as
+`math::add` as in the following example:
 
 ```move
 {{#include ../../../packages/samples/sources/move-basics/function_use.move:use_math}}
@@ -44,15 +45,15 @@ has already been imported, you can access it directly as `math::add` as in the f
 ## Multiple return values
 
 Move functions can return multiple values, which is particularly useful when you need to return more
-than one piece of data from a function. The return type is specified as a tuple of types, and the return
-value is provided as a tuple of expressions:
+than one piece of data from a function. The return type is specified as a tuple of types, and the
+return value is provided as a tuple of expressions:
 
 ```move
 {{#include ../../../packages/samples/sources/move-basics/function.move:tuple_return}}
 ```
 
-The result of a function call with a tuple return has to be unpacked into variables via the `let (tuple)`
-syntax:
+The result of a function call with a tuple return has to be unpacked into variables via the
+`let (tuple)` syntax:
 
 ```move
 {{#include ../../../packages/samples/sources/move-basics/function.move:tuple_return_imm}}
@@ -71,6 +72,6 @@ If some of the arguments are not used, they can be ignored with the `_` symbol:
 {{#include ../../../packages/samples/sources/move-basics/function.move:tuple_return_ignore}}
 ```
 
-## Further reading
+## Further Reading
 
 - [Functions](/reference/functions.html) in the Move Reference.

--- a/book/src/move-basics/generics.md
+++ b/book/src/move-basics/generics.md
@@ -2,8 +2,8 @@
 
 Generics are a way to define a type or function that can work with any type. This is useful when you
 want to write a function which can be used with different types, or when you want to define a type
-that can hold any other type. Generics are the foundation of many advanced features in Move including
-collections, abstract implementations, and more.
+that can hold any other type. Generics are the foundation of many advanced features in Move
+including collections, abstract implementations, and more.
 
 ## In the Standard Library
 
@@ -23,23 +23,22 @@ enclosed in angle brackets (`<` and `>`). The generic parameters are separated b
 In the example above, `Container` is a generic type with a single type parameter `T`, the `value`
 field of the container stores the `T`. The `new` function is a generic function with a single type
 parameter `T`, and it returns a `Container` with the given value. Generic types must be initialized
-with a concrete type, and generic functions must be called with a concrete type, although in some cases
-the Move compiler can infer the correct type.
+with a concrete type, and generic functions must be called with a concrete type, although in some
+cases the Move compiler can infer the correct type.
 
 ```move
 {{#include ../../../packages/samples/sources/move-basics/generics.move:test_container}}
 ```
 
-In the test function `test_generic`, we demonstrate three equivalent ways to
-create a new `Container` with a `u8` value. Because numeric constants have
-ambiguous types, we must specify the type of the number literal somewhere (in
-the type of the container, the parameter to `new`, or the number literal
-itself); once we specify one of these the compiler can infer the others.
+In the test function `test_generic`, we demonstrate three equivalent ways to create a new
+`Container` with a `u8` value. Because numeric constants have ambiguous types, we must specify the
+type of the number literal somewhere (in the type of the container, the parameter to `new`, or the
+number literal itself); once we specify one of these the compiler can infer the others.
 
 ## Multiple Type Parameters
 
-You can define a type or function with multiple type parameters. The type parameters are
-separated by commas.
+You can define a type or function with multiple type parameters. The type parameters are separated
+by commas.
 
 ```move
 {{#include ../../../packages/samples/sources/move-basics/generics.move:pair}}
@@ -47,8 +46,8 @@ separated by commas.
 
 In the example above, `Pair` is a generic type with two type parameters `T` and `U`, and the
 `new_pair` function is a generic function with two type parameters `T` and `U`. The function returns
-a `Pair` with the given values. The order of the type parameters is important, and should match
-the order of the type parameters in the type signature.
+a `Pair` with the given values. The order of the type parameters is important, and should match the
+order of the type parameters in the type signature.
 
 ```move
 {{#include ../../../packages/samples/sources/move-basics/generics.move:test_pair}}
@@ -61,23 +60,24 @@ to compare two types, we'd see that the type signatures are different, and canno
 {{#include ../../../packages/samples/sources/move-basics/generics.move:test_pair_swap}}
 ```
 
-Since the types for `pair1` and `pair2` are different, the comparison `pair1 == pair2` will not compile.
+Since the types for `pair1` and `pair2` are different, the comparison `pair1 == pair2` will not
+compile.
 
 ## Why Generics?
 
 In the examples above we focused on instantiating generic types and calling generic functions to
-create instances of these types. However, the real power of generics lies in their ability to define shared
-behavior for the base, generic type, and then use it independently of the concrete types. This is
-especially useful when working with collections, abstract implementations, and other advanced
-features in Move.
+create instances of these types. However, the real power of generics lies in their ability to define
+shared behavior for the base, generic type, and then use it independently of the concrete types.
+This is especially useful when working with collections, abstract implementations, and other
+advanced features in Move.
 
 ```move
 {{#include ../../../packages/samples/sources/move-basics/generics.move:user}}
 ```
 
 In the example above, `User` is a generic type with a single type parameter `T`, with shared fields
-`name`, `age`, and the generic `metadata` field, which can store any type. No matter what
-`metadata` is, all instances of `User` will contain the same fields and methods.
+`name`, `age`, and the generic `metadata` field, which can store any type. No matter what `metadata`
+is, all instances of `User` will contain the same fields and methods.
 
 ```move
 {{#include ../../../packages/samples/sources/move-basics/generics.move:update_user}}
@@ -104,8 +104,8 @@ parameter `T`.
 
 In the example above, we demonstrate how to create two different instances of `Coin` with different
 phantom type parameters `USD` and `EUR`. The type parameter `T` is not used in the fields or methods
-of the `Coin` type, but it is used to differentiate between different types of coins. This helps ensure
-that the `USD` and `EUR` coins are not mistakenly mixed up.
+of the `Coin` type, but it is used to differentiate between different types of coins. This helps
+ensure that the `USD` and `EUR` coins are not mistakenly mixed up.
 
 ## Constraints on Type Parameters
 

--- a/book/src/move-basics/module.md
+++ b/book/src/move-basics/module.md
@@ -13,10 +13,10 @@ Notes:
  -->
 
 A module is the base unit of code organization in Move. Modules are used to group and isolate code,
-and all members of the module are private to the module by default. In this section you will
-learn how to define a module, declare its members, and access it from other modules.
+and all members of the module are private to the module by default. In this section you will learn
+how to define a module, declare its members, and access it from other modules.
 
-## Module declaration
+## Module Declaration
 
 Modules are declared using the `module` keyword followed by the package address, module name,
 semicolon, and the module body. The module name should be in `snake_case` - all lowercase letters
@@ -27,7 +27,8 @@ the module name - for example, a `donut_shop` module should be stored in the `do
 You can read more about coding conventions in the
 [Coding Conventions](../guides/coding-conventions.md) section.
 
-> If you need to declare more than one module in a file, you must use [Module Block](#module-block) syntax.
+> If you need to declare more than one module in a file, you must use [Module Block](#module-block)
+> syntax.
 
 ```Move
 {{#include ../../../packages/samples/sources/move-basics/module-label.move:module}}
@@ -41,12 +42,12 @@ Structs, functions, constants and imports all part of the module:
 - [Imports](./importing-modules.md)
 - [Struct Methods](./struct-methods.md)
 
-## Address / Named address
+## Address / Named Address
 
-The module address can be specified as both: an address _literal_ (does not require the `@` prefix) or a
-named address specified in the [Package Manifest](../concepts/manifest.md). In the example below,
-both are identical because there's a `book = "0x0"` record in the `[addresses]` section of the
-`Move.toml`.
+The module address can be specified as both: an address _literal_ (does not require the `@` prefix)
+or a named address specified in the [Package Manifest](../concepts/manifest.md). In the example
+below, both are identical because there's a `book = "0x0"` record in the `[addresses]` section of
+the `Move.toml`.
 
 ```Move
 {{#include ../../../packages/samples/sources/move-basics/module.move:address_literal}}
@@ -60,7 +61,7 @@ Addresses section in the Move.toml:
 book = "0x0"
 ```
 
-## Module members
+## Module Members
 
 Module members are declared inside the module body. To illustrate that, let's define a simple module
 with a struct, a function and a constant:
@@ -69,17 +70,17 @@ with a struct, a function and a constant:
 {{#include ../../../packages/samples/sources/move-basics/module-members.move:members}}
 ```
 
-## Module block
+## Module Block
 
-The pre-2024 edition of Move required the body of the module to be a _module block_ - the contents of the 
-module needed to be surrounded by curly braces `{}`. The main reason to use block syntax and not _label_ 
-syntax is if you need to define more than one module in a file. However, using module blocks is not 
-recommended practice.
+The pre-2024 edition of Move required the body of the module to be a _module block_ - the contents
+of the module needed to be surrounded by curly braces `{}`. The main reason to use block syntax and
+not _label_ syntax is if you need to define more than one module in a file. However, using module
+blocks is not recommended practice.
 
 ```Move
 {{#include ../../../packages/samples/sources/move-basics/module.move:members}}
 ```
 
-## Further reading
+## Further Reading
 
 - [Modules](/reference/modules.html) in the Move Reference.

--- a/book/src/move-basics/module.md
+++ b/book/src/move-basics/module.md
@@ -42,7 +42,7 @@ Structs, functions, constants and imports all part of the module:
 - [Imports](./importing-modules.md)
 - [Struct Methods](./struct-methods.md)
 
-## Address / Named Address
+## Address and Named Address
 
 The module address can be specified as both: an address _literal_ (does not require the `@` prefix)
 or a named address specified in the [Package Manifest](../concepts/manifest.md). In the example

--- a/book/src/move-basics/option.md
+++ b/book/src/move-basics/option.md
@@ -1,65 +1,70 @@
 # Option
 
-`Option` is a type that represents an optional value which may or may not exist. The concept of `Option`
-in Move is borrowed from Rust, and it is a very useful primitive in Move. `Option` is defined in the
-[Standard Library](./standard-library.md), and is defined as follows:
+`Option` is a type that represents an optional value which may or may not exist. The concept of
+`Option` in Move is borrowed from Rust, and it is a very useful primitive in Move. `Option` is
+defined in the [Standard Library](./standard-library.md), and is defined as follows:
 
 ```move
-// File: move-stdlib/source/option.move
+module std::option;
+
 /// Abstraction of a value that may or may not be present.
-struct Option<Element> has copy, drop, store {
+public struct Option<Element> has copy, drop, store {
     vec: vector<Element>
 }
 ```
 
+_See [full documentation for std::option][option-stdlib] module._
+
 > The 'std::option' module is implicitly imported in every module, so you don't need to add an
 > explicit import.
 
-The `Option` type is a generic type with an `Element` type parameter. It contains a single field, `vec`,
-which is a `vector` of `Element`. The vector can have a length of 0 or 1, representing the
+The `Option` type is a generic type with an `Element` type parameter. It contains a single field,
+`vec`, which is a `vector` of `Element`. The vector can have a length of 0 or 1, representing the
 absence or presence of a value, respectively.
 
-> Note: You might be surprised that `Option` is a `struct` containing a `vector` instead of an [enum][enum-reference].
-> This is for historical reasons: `Option` was added to Move before it had support for enums.
+> Note: You might be surprised that `Option` is a `struct` containing a `vector` instead of an
+> [enum][enum-reference]. This is for historical reasons: `Option` was added to Move before it had
+> support for enums.
 
-[enum-reference]: /reference/enums.html
-
-The `Option` type has two variants: `Some` and `None`. The `Some` variant contains a value, while the `None` variant
-represents the absence of a value. The `Option` type is used to represent the absence of a value in
-a type-safe way, avoiding the need for empty or `undefined` values.
+The `Option` type has two variants: `Some` and `None`. The `Some` variant contains a value, while
+the `None` variant represents the absence of a value. The `Option` type is used to represent the
+absence of a value in a type-safe way, avoiding the need for empty or `undefined` values.
 
 ## In Practice
 
-To showcase why the `Option` type is necessary, let's look at an example. Consider an application which
-takes a user input and stores it in a variable. Some fields are required, and some are optional. For
-example, a user's middle name is optional. While we could use an empty string to represent the
-absence of a middle name, it would require extra checks to differentiate between an empty string and
-a missing middle name. Instead, we can use the `Option` type to represent the middle name.
+To showcase why the `Option` type is necessary, let's look at an example. Consider an application
+which takes a user input and stores it in a variable. Some fields are required, and some are
+optional. For example, a user's middle name is optional. While we could use an empty string to
+represent the absence of a middle name, it would require extra checks to differentiate between an
+empty string and a missing middle name. Instead, we can use the `Option` type to represent the
+middle name.
 
 ```move
 {{#include ../../../packages/samples/sources/move-basics/option.move:registry}}
 ```
 
-In the previous example, the `middle_name` field is of type `Option<String>`. This means that the `middle_name`
-field can either contain a String value, wrapped in Some, or be explicitly empty, represented by None. Using
-the `Option` type makes the optional nature of the field clear, avoiding ambiguity and the need for extra
-checks to differentiate between an empty string and a missing middle name.
+In the previous example, the `middle_name` field is of type `Option<String>`. This means that the
+`middle_name` field can either contain a String value, wrapped in Some, or be explicitly empty,
+represented by None. Using the `Option` type makes the optional nature of the field clear, avoiding
+ambiguity and the need for extra checks to differentiate between an empty string and a missing
+middle name.
 
-## Creating and using Option values
+## Creating and Using Option values
 
-The `Option` type, along with the `std::option` module, is implicitly imported in Move. This means you can use
-the `Option` type directly without needing a `use` statement.
+The `Option` type, along with the `std::option` module, is implicitly imported in Move. This means
+you can use the `Option` type directly without needing a `use` statement.
 
 To create a value of the `Option` type, you can use the `option::some` or `option::none` methods.
-`Option` values also support several operations (borrowing will be discussed in
-the [references](references.md#references-1) chapter):
+`Option` values also support several operations (borrowing will be discussed in the
+[references](references.md#references-1) chapter):
 
 ```move
 {{#include ../../../packages/samples/sources/move-basics/option.move:usage}}
 ```
 
-## References
+## Further Reading
 
- - [`std::option`][option-stdlib] in the standard library
+- [std::option][option-stdlib] in the standard library
 
+[enum-reference]: /reference/enums.html
 [option-stdlib]: https://docs.sui.io/references/framework/std/option

--- a/book/src/move-basics/ownership-and-scope.md
+++ b/book/src/move-basics/ownership-and-scope.md
@@ -110,8 +110,8 @@ public fun owner() {
 } // a is dropped here
 ```
 
-However, if we return a value from a block, the ownership of the variable is transferred to
-the caller of the block.
+However, if we return a value from a block, the ownership of the variable is transferred to the
+caller of the block.
 
 ```move
 module book::ownership;
@@ -130,9 +130,9 @@ public fun owner(): u8 {
 
 Some types in Move are _copyable_, which means that they can be copied without transferring
 ownership. This is useful for types that are small and cheap to copy, such as integers and booleans.
-The Move compiler will automatically copy these types when they are passed to or returned
-from a function, or when they're _moved_ to another scope and then accessed in their original scope.
+The Move compiler will automatically copy these types when they are passed to or returned from a
+function, or when they're _moved_ to another scope and then accessed in their original scope.
 
-## Further reading
+## Further Reading
 
 - [Local Variables and Scopes](/reference/variables.html) in the Move Reference.

--- a/book/src/move-basics/primitive-types.md
+++ b/book/src/move-basics/primitive-types.md
@@ -9,10 +9,10 @@ other types. The primitive types are:
 - [Unsigned Integers](#integer-types)
 - [Addresses](./address.md) - covered in the next section
 
-Before we get to the primitive types, let's first take a look at how to declare and assign variables in
-Move.
+Before we get to the primitive types, let's first take a look at how to declare and assign variables
+in Move.
 
-## Variables and assignment
+## Variables and Assignment
 
 Variables are declared using the `let` keyword. They are immutable by default, but can be made
 mutable by adding the `mut` keyword:
@@ -47,7 +47,8 @@ Variables can also be shadowed by re-declaring them.
 ## Booleans
 
 The `bool` type represents a boolean value - yes or no, true or false. It has two possible values:
-`true` and `false`, which are keywords in Move. For booleans, the compiler can always infer the type from the value, so there is no need to explicitly specify it.
+`true` and `false`, which are keywords in Move. For booleans, the compiler can always infer the type
+from the value, so there is no need to explicitly specify it.
 
 ```move
 {{#include ../../../packages/samples/sources/move-basics/primitive-types.move:boolean}}
@@ -71,12 +72,11 @@ Move supports unsigned integers of various sizes, from 8-bit to 256-bit. The int
 {{#include ../../../packages/samples/sources/move-basics/primitive-types.move:integers}}
 ```
 
-While boolean literals like `true` and `false` are clearly booleans, an integer
-literal like `42` could be any of the integer types. In most of the cases, the
-compiler will infer the type from the value, usually defaulting to `u64`.
-However, sometimes the compiler is unable to infer the type and will require an
-explicit type annotation. It can either be provided during assignment or by
-using a type suffix.
+While boolean literals like `true` and `false` are clearly booleans, an integer literal like `42`
+could be any of the integer types. In most of the cases, the compiler will infer the type from the
+value, usually defaulting to `u64`. However, sometimes the compiler is unable to infer the type and
+will require an explicit type annotation. It can either be provided during assignment or by using a
+type suffix.
 
 ```move
 {{#include ../../../packages/samples/sources/move-basics/primitive-types.move:integer_explicit_type}}
@@ -98,9 +98,9 @@ multiplication, division, and modulus (remainder). The syntax for these operatio
 > For more operations, including bitwise operations, please refer to the
 > [Move Reference](/reference/primitive-types/integers.html#bitwise).
 
-The types of the operands _must match_, or the compiler will raise an error. The result of
-the operation will be of the same type as the operands. To perform operations on different types,
-the operands need to be cast to the same type.
+The types of the operands _must match_, or the compiler will raise an error. The result of the
+operation will be of the same type as the operands. To perform operations on different types, the
+operands need to be cast to the same type.
 
 <!-- TODO: add examples + parentheses for arithmetic operations -->
 <!-- TODO: add bitwise operators -->
@@ -138,7 +138,7 @@ let y = 1u8;
 let z = x + y;
 ```
 
-## Further reading
+## Further Reading
 
 - [Bool](/reference/primitive-types/bool.html) in the Move Reference.
 - [Integer](/reference/primitive-types/integers.html) in the Move Reference.

--- a/book/src/move-basics/references.md
+++ b/book/src/move-basics/references.md
@@ -20,8 +20,8 @@ In the [Ownership and Scope](./ownership-and-scope.md) section, we explained tha
 passed to a function, it is _moved_ to the function's scope. This means that the function becomes
 the owner of the value, and the original scope (owner) can no longer use it. This is an important
 concept in Move, as it ensures that the value is not used in multiple places at the same time.
-However, there are use cases when we want to pass a value to a function but retain ownership.
-This is where references come into play.
+However, there are use cases when we want to pass a value to a function but retain ownership. This
+is where references come into play.
 
 To illustrate this, let's consider a simple example - an application for a metro (subway) pass. We
 will look at 4 different scenarios where a card can be:
@@ -48,10 +48,10 @@ module book::metro_pass;
 
 ## References
 
-References are a way to _show_ a value to a function without giving up ownership. In our case,
-when we show the Card to the inspector, we don't want to give up ownership of it, and we don't
-allow the inspector to use up any of our rides. We just want to allow the _reading_ of the value
-of our Card and to prove its ownership.
+References are a way to _show_ a value to a function without giving up ownership. In our case, when
+we show the Card to the inspector, we don't want to give up ownership of it, and we don't allow the
+inspector to use up any of our rides. We just want to allow the _reading_ of the value of our Card
+and to prove its ownership.
 
 To do so, in the function signature, we use the `&` symbol to indicate that we are passing a
 _reference_ to the value, not the value itself.
@@ -70,8 +70,8 @@ method to get a reference to the value wrapped by an `Option` is called `borrow`
 
 ## Mutable Reference
 
-In some cases, we want to allow the function to modify the Card. For example, when using the Card
-at a turnstile, we need to deduct a ride. To achieve this, we use the `&mut` keyword in the function
+In some cases, we want to allow the function to modify the Card. For example, when using the Card at
+a turnstile, we need to deduct a ride. To achieve this, we use the `&mut` keyword in the function
 signature.
 
 ```move
@@ -83,20 +83,20 @@ function can spend rides.
 
 ## Passing by Value
 
-Lastly, let's illustrate what happens when we pass the value itself to the function. In
-this case, the function takes the ownership of the value, making it inaccessible in the original
-scope. The owner of the Card can recycle it and thereby relinquish ownership to the function.
+Lastly, let's illustrate what happens when we pass the value itself to the function. In this case,
+the function takes the ownership of the value, making it inaccessible in the original scope. The
+owner of the Card can recycle it and thereby relinquish ownership to the function.
 
 ```move
 {{#include ../../../packages/samples/sources/move-basics/references.move:move}}
 ```
 
-In the `recycle` function, the Card is passed by value, transferring ownership to the function.
-This allows it to be unpacked and destroyed.
+In the `recycle` function, the Card is passed by value, transferring ownership to the function. This
+allows it to be unpacked and destroyed.
 
-> Note: In Move, `_` is a wildcard pattern used in destructuring to ignore a field while still consuming the value.
-> Destructuring must match all fields in a struct type. If a struct has fields, you must list all of them
-> explicitly or use `_` to ignore unwanted fields.
+> Note: In Move, `_` is a wildcard pattern used in destructuring to ignore a field while still
+> consuming the value. Destructuring must match all fields in a struct type. If a struct has fields,
+> you must list all of them explicitly or use `_` to ignore unwanted fields.
 
 ## Full Example
 
@@ -105,6 +105,11 @@ To illustrate the full flow of the application, let's put all the pieces togethe
 ```move
 {{#include ../../../packages/samples/sources/move-basics/references.move:move_2024}}
 ```
+
+## Further Reading
+
+- [References](https://move-book.com/reference/primitive-types/references.html) in the Move
+  Reference.
 
 <!-- ## Dereference and Copy -->
 

--- a/book/src/move-basics/standard-library.md
+++ b/book/src/move-basics/standard-library.md
@@ -16,19 +16,19 @@ and which module implements it.
 <!-- Custom CSS addition in the theme/custom.css  -->
 <div class="modules-table">
 
-| Module                                                                           | Description                                                                | Chapter                                                                    |
-| -------------------------------------------------------------------------------- | -------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
-| [std::string](https://docs.sui.io/references/framework/std/string)       | Provides basic string operations                                           | [String](./string.md)                                                      |
-| [std::ascii](https://docs.sui.io/references/framework/std/ascii)         | Provides basic ASCII operations                                            | -                                                      |
-| [std::option](https://docs.sui.io/references/framework/std/option)       | Implements `Option<T>`                                                  | [Option](./option.md)                                                      |
-| [std::vector](https://docs.sui.io/references/framework/std/vector)       | Native operations on the vector type                                       | [Vector](./vector.md)                                                      |
-| [std::bcs](https://docs.sui.io/references/framework/std/bcs)             | Contains the `bcs::to_bytes()` function                                    | [BCS](../programmability/bcs.md)                                               |
-| [std::address](https://docs.sui.io/references/framework/std/address)     | Contains a single `address::length` function                               | [Address](./address.md)                                                    |
-| [std::type_name](https://docs.sui.io/references/framework/std/type_name) | Allows runtime _type reflection_                                           | [Type Reflection](./type-reflection.md)                                    |
-| [std::hash](https://docs.sui.io/references/framework/std/hash)                                                                        | Hashing functions: `sha2_256` and `sha3_256`                               | - |
-| [std::debug](https://docs.sui.io/references/framework/std/debug)                                                                       | Contains debugging functions, which are available in only in **test** mode | -                                                |
-| [std::bit_vector](https://docs.sui.io/references/framework/std/bit_vector)                                                                  | Provides operations on bit vectors                                         | -                                                                      |
-| [std::fixed_point32](https://docs.sui.io/references/framework/std/fixed_point32)                                                               | Provides the `FixedPoint32` type                                           | -                                                    |
+| Module                                                                           | Description                                                                | Chapter                                 |
+| -------------------------------------------------------------------------------- | -------------------------------------------------------------------------- | --------------------------------------- |
+| [std::string](https://docs.sui.io/references/framework/std/string)               | Provides basic string operations                                           | [String](./string.md)                   |
+| [std::ascii](https://docs.sui.io/references/framework/std/ascii)                 | Provides basic ASCII operations                                            | -                                       |
+| [std::option](https://docs.sui.io/references/framework/std/option)               | Implements `Option<T>`                                                     | [Option](./option.md)                   |
+| [std::vector](https://docs.sui.io/references/framework/std/vector)               | Native operations on the vector type                                       | [Vector](./vector.md)                   |
+| [std::bcs](https://docs.sui.io/references/framework/std/bcs)                     | Contains the `bcs::to_bytes()` function                                    | [BCS](../programmability/bcs.md)        |
+| [std::address](https://docs.sui.io/references/framework/std/address)             | Contains a single `address::length` function                               | [Address](./address.md)                 |
+| [std::type_name](https://docs.sui.io/references/framework/std/type_name)         | Allows runtime _type reflection_                                           | [Type Reflection](./type-reflection.md) |
+| [std::hash](https://docs.sui.io/references/framework/std/hash)                   | Hashing functions: `sha2_256` and `sha3_256`                               | -                                       |
+| [std::debug](https://docs.sui.io/references/framework/std/debug)                 | Contains debugging functions, which are available in only in **test** mode | -                                       |
+| [std::bit_vector](https://docs.sui.io/references/framework/std/bit_vector)       | Provides operations on bit vectors                                         | -                                       |
+| [std::fixed_point32](https://docs.sui.io/references/framework/std/fixed_point32) | Provides the `FixedPoint32` type                                           | -                                       |
 
 </div>
 
@@ -44,8 +44,8 @@ not be imported directly, as their functions are available on every integer valu
 <!-- Custom CSS addition in the theme/custom.css  -->
 <div class="modules-table">
 
-| Module                                                                 | Description                   |
-| ---------------------------------------------------------------------- | ----------------------------- |
+| Module                                                         | Description                   |
+| -------------------------------------------------------------- | ----------------------------- |
 | [std::u8](https://docs.sui.io/references/framework/std/u8)     | Functions for the `u8` type   |
 | [std::u16](https://docs.sui.io/references/framework/std/u16)   | Functions for the `u16` type  |
 | [std::u32](https://docs.sui.io/references/framework/std/u32)   | Functions for the `u32` type  |
@@ -57,7 +57,8 @@ not be imported directly, as their functions are available on every integer valu
 
 ## Exported Addresses
 
-The Standard Library exports a single named address - `std = 0x1`. Note the alias `std` is defined here.
+The Standard Library exports a single named address - `std = 0x1`. Note the alias `std` is defined
+here.
 
 ```toml
 [addresses]

--- a/book/src/move-basics/string.md
+++ b/book/src/move-basics/string.md
@@ -5,8 +5,9 @@ implementations for strings in the [Standard Library](./standard-library.md). Th
 module defines a `String` type and methods for UTF-8 encoded strings, and the second module,
 `std::ascii`, provides an ASCII `String` type and its methods.
 
-> The Sui execution environment automatically converts bytevector into `String` in transaction inputs.
-> As a result, in many cases, constructing a String directly within the [Transaction Block](./../concepts/what-is-a-transaction.md) is unnecessary.
+> The Sui execution environment automatically converts bytevector into `String` in transaction
+> inputs. As a result, in many cases, constructing a String directly within the
+> [Transaction Block](./../concepts/what-is-a-transaction.md) is unnecessary.
 
 <!--
 
@@ -32,23 +33,26 @@ bytes.
 
 ## Working with UTF-8 Strings
 
-While there are two types of strings (`string` and `ascii`) in the standard library, the `string` module
-should be considered the default. It has native implementations of many common operations, leveraging 
-low-level, optimized runtime code for superior performance. In contrast, the `ascii` module is fully 
-implemented in Move, relying on higher-level abstractions and making it less suitable for 
-performance-critical tasks.
+While there are two types of strings (`string` and `ascii`) in the standard library, the `string`
+module should be considered the default. It has native implementations of many common operations,
+leveraging low-level, optimized runtime code for superior performance. In contrast, the `ascii`
+module is fully implemented in Move, relying on higher-level abstractions and making it less
+suitable for performance-critical tasks.
 
 ### Definition
 
 The `String` type in the `std::string` module is defined as follows:
 
 ```move
-// File: move-stdlib/sources/string.move
+module std::string;
+
 /// A `String` holds a sequence of bytes which is guaranteed to be in utf8 format.
 public struct String has copy, drop, store {
     bytes: vector<u8>,
 }
 ```
+
+_See [full documentation for std::string][string-stdlib] module._
 
 ### Creating a String
 
@@ -96,9 +100,9 @@ sure that the bytes you are passing are valid, you should use the `try_utf8` met
 returns an `Option<String>`, which contains no value if the bytes are not valid UTF-8, and a string
 otherwise.
 
-> Hint: Functions with names starting with `try_*` typically return an `Option`. If the operation succeeds, the 
-> result is wrapped in `Some`. If it fails, the function returns `None`. This naming convention, commonly 
-> used in Move, is inspired by Rust.
+> Hint: Functions with names starting with `try_*` typically return an `Option`. If the operation
+> succeeds, the result is wrapped in `Some`. If it fails, the function returns `None`. This naming
+> convention, commonly used in Move, is inspired by Rust.
 
 ```move
 {{#include ../../../packages/samples/sources/move-basics/string.move:safe_utf8}}
@@ -111,11 +115,18 @@ because UTF-8 is a variable-length encoding, and the length of a character can b
 4 bytes. Similarly, the `length()` method returns the number of bytes in the string, not the number
 of characters.
 
-
-However, methods like `sub_string` and `insert` validate character boundaries and abort if the 
+However, methods like `sub_string` and `insert` validate character boundaries and abort if the
 specified index falls within the middle of a character.
-
 
 ## ASCII Strings
 
 This section is coming soon!
+
+## Further Reading
+
+- [std::string][string-stdlib] module documentation.
+- [std::ascii][ascii-stdlib] module documentation.
+
+[enum-reference]: /reference/enums.html
+[string-stdlib]: https://docs.sui.io/references/framework/std/string
+[ascii-stdlib]: https://docs.sui.io/references/framework/std/ascii

--- a/book/src/move-basics/struct-methods.md
+++ b/book/src/move-basics/struct-methods.md
@@ -1,19 +1,18 @@
 # Struct Methods
 
-Move Compiler supports _receiver syntax_ `e.f()`, which allows defining methods which can be called on
-instances of a struct. The term "receiver" specifically refers to the instance that receives the
-method call. This is like the method syntax in other programming languages. It is a
-convenient way to define functions that operate on the fields of a struct, providing direct access
-to the struct's fields and creating cleaner, more intuitive code than passing the struct as a parameter.
+Move Compiler supports _receiver syntax_ `e.f()`, which allows defining methods which can be called
+on instances of a struct. The term "receiver" specifically refers to the instance that receives the
+method call. This is like the method syntax in other programming languages. It is a convenient way
+to define functions that operate on the fields of a struct, providing direct access to the struct's
+fields and creating cleaner, more intuitive code than passing the struct as a parameter.
 
 ## Method syntax
 
-If the first argument of a function is a struct internal to the module that
-defines the function, then the function can be called using the `.` operator.
-However, if the type of the first argument is defined in another module, then
-method won't be associated with the struct by default. In this case, the `.`
-operator syntax is not available, and the function must be called using
-standard function call syntax.
+If the first argument of a function is a struct internal to the module that defines the function,
+then the function can be called using the `.` operator. However, if the type of the first argument
+is defined in another module, then method won't be associated with the struct by default. In this
+case, the `.` operator syntax is not available, and the function must be called using standard
+function call syntax.
 
 When a module is imported, its methods are automatically associated with the struct.
 
@@ -53,9 +52,10 @@ without the prefix, as the compiler automatically associates the methods with th
 structs.
 
 > Note: In the test function, `hero.health()` is calling the aliased method, not directly accessing
-> the private `health` field. While the `Hero` and `Villain` structs are public, their fields remain private
-> to the module. The method call `hero.health()` uses the public alias defined by `public use fun
-> hero_health as Hero.health`, which provides controlled access to the private field.
+> the private `health` field. While the `Hero` and `Villain` structs are public, their fields remain
+> private to the module. The method call `hero.health()` uses the public alias defined by
+> `public use fun hero_health as Hero.health`, which provides controlled access to the private
+> field.
 
 ## Aliasing an external module's method
 
@@ -69,6 +69,6 @@ bytes.
 {{#include ../../../packages/samples/sources/move-basics/struct-methods-3.move:hero_to_bytes}}
 ```
 
-## Further reading
+## Further Reading
 
 - [Method Syntax](/reference/method-syntax.html) in the Move Reference.

--- a/book/src/move-basics/struct-methods.md
+++ b/book/src/move-basics/struct-methods.md
@@ -57,7 +57,7 @@ structs.
 > `public use fun hero_health as Hero.health`, which provides controlled access to the private
 > field.
 
-## Aliasing an external module's method
+<!-- ## Aliasing an external module's method
 
 It is also possible to associate a function defined in another module with a struct from the current
 module. Following the same approach, we can create an alias for the method defined in another
@@ -67,7 +67,7 @@ bytes.
 
 ```move
 {{#include ../../../packages/samples/sources/move-basics/struct-methods-3.move:hero_to_bytes}}
-```
+``` -->
 
 ## Further Reading
 

--- a/book/src/move-basics/struct.md
+++ b/book/src/move-basics/struct.md
@@ -65,8 +65,8 @@ Struct fields are private and can be accessed only by the module defining the st
 ## Unpacking a struct
 
 Structs are non-discardable by default, meaning that the initialized struct value must be used,
-either by storing it or unpacking it. Unpacking a struct means deconstructing it into its fields. This is done using
-the `let` keyword followed by the struct name and the field names.
+either by storing it or unpacking it. Unpacking a struct means deconstructing it into its fields.
+This is done using the `let` keyword followed by the struct name and the field names.
 
 ```move
 {{#include ../../../packages/samples/sources/move-basics/struct.move:unpack}}
@@ -81,6 +81,6 @@ unused.
 {{#include ../../../packages/samples/sources/move-basics/struct.move:unpack_ignore}}
 ```
 
-## Further reading
+## Further Reading
 
 - [Structs](/reference/structs.html) in the Move Reference.

--- a/book/src/move-basics/testing.md
+++ b/book/src/move-basics/testing.md
@@ -4,12 +4,12 @@ Testing is a crucial aspect of software development, especially in blockchain ap
 security and correctness are paramount. In this section, we will cover the fundamentals of testing
 in Move, including how to write and organize tests effectively.
 
-## The `#[test]` attribute
+## The `#[test]` Attribute
 
 Tests in Move are functions marked with the `#[test]` attribute. This attribute tells the compiler
-that the function is a test function and should be run when tests are executed. Test
-functions are regular functions, but they must take no arguments and have no return value. They
-are excluded from the bytecode and are never published.
+that the function is a test function and should be run when tests are executed. Test functions are
+regular functions, but they must take no arguments and have no return value. They are excluded from
+the bytecode and are never published.
 
 ```move
 module book::testing;
@@ -33,8 +33,8 @@ fun simple_test() {
 ## Running Tests
 
 To run tests, you can use the `sui move test` command. This command will first build the package in
-_test mode_ and then run all tests found in the package. In test mode, modules from both
-`sources/` and `tests/` directories are processed and their tests executed.
+_test mode_ and then run all tests found in the package. In test mode, modules from both `sources/`
+and `tests/` directories are processed and their tests executed.
 
 ```bash
 $ sui move test
@@ -53,15 +53,15 @@ $ sui move test
 
 ## Test Fail Cases with `#[expected_failure]`
 
-Tests for fail cases can be marked with `#[expected_failure]`. This attribute, when added to a `#[test]`
-function, tells the compiler that the test is expected to fail. This is useful when you want to test
-that a function fails when a certain condition is met.
+Tests for fail cases can be marked with `#[expected_failure]`. This attribute, when added to a
+`#[test]` function, tells the compiler that the test is expected to fail. This is useful when you
+want to test that a function fails when a certain condition is met.
 
 > Note: This attribute can only be added to a `#[test]` function.
 
 The attribute can take an argument specifying the expected abort code that should be returned if the
-test fails. If the test returns an abort code different from the one specified in the argument, it will fail. Likewise, if execution does
-not result in an abort, the test will also fail.
+test fails. If the test returns an abort code different from the one specified in the argument, it
+will fail. Likewise, if execution does not result in an abort, the test will also fail.
 
 ```move
 module book::testing_failure;
@@ -86,8 +86,8 @@ other modules. This is the only case where constants can be used and "accessed" 
 
 ## Utilities with `#[test_only]`
 
-In some cases, it is helpful to give the test environment access to some internal functions
-or features. This simplifies the testing process and allows for more thorough testing. However, it is
+In some cases, it is helpful to give the test environment access to some internal functions or
+features. This simplifies the testing process and allows for more thorough testing. However, it is
 important to remember that these functions should not be included in the final package. This is
 where the `#[test_only]` attribute comes in handy.
 

--- a/book/src/move-basics/type-reflection.md
+++ b/book/src/move-basics/type-reflection.md
@@ -1,26 +1,25 @@
 # Type Reflection
 
 In programming languages, _reflection_ is the ability of a program to examine and modify its own
-structure and behavior. Move has a limited form of reflection that allows you to inspect the
-type of a value at runtime. This is useful when you need to store type information in a homogeneous
+structure and behavior. Move has a limited form of reflection that allows you to inspect the type of
+a value at runtime. This is useful when you need to store type information in a homogeneous
 collection, or when you need to check if a type belongs to a package.
 
 Type reflection is implemented in the [Standard Library](./standard-library.md) module
-[`std::type_name`][type-name-docs]. Expressed very roughly, it gives a single function `get<T>()` which returns the
-name of the type `T`.
-
-[type-name-docs]: https://docs.sui.io/references/framework/std/type_name
+[`std::type_name`][type-name-stdlib]. Expressed very roughly, it gives a single function `get<T>()`
+which returns the name of the type `T`.
 
 ## In practice
 
-The module is straightforward, and operations allowed on the result are limited to getting a
-string representation and extracting the module and address of the type.
+The module is straightforward, and operations allowed on the result are limited to getting a string
+representation and extracting the module and address of the type.
 
 ```move
 {{#include ../../../packages/samples/sources/move-basics/type-reflection.move:main}}
 ```
 
-## Further reading
+## Further Reading
 
-Type reflection is an important part of the language, and it is a crucial part of some of the more
-advanced patterns.
+- [std::type_name][type-name-stdlib] module documentation.
+
+[type-name-stdlib]: https://docs.sui.io/references/framework/std/type_name

--- a/book/src/move-basics/vector.md
+++ b/book/src/move-basics/vector.md
@@ -1,17 +1,16 @@
 # Vector
 
 Vectors are a native way to store collections of elements in Move. They are similar to arrays in
-other programming languages, but with a few differences. In this section, we introduce
-the `vector` type and its operations.
+other programming languages, but with a few differences. In this section, we introduce the `vector`
+type and its operations.
 
 ## Vector syntax
 
 The `vector` type is written using the `vector` keyword followed by the type of the elements in
 angle brackets. The type of the elements can be any valid Move type, including other vectors.
 
-Move
-has a vector literal syntax that allows you to create vectors using the `vector` keyword followed by
-square brackets containing the elements (or no elements for an empty vector).
+Move has a vector literal syntax that allows you to create vectors using the `vector` keyword
+followed by square brackets containing the elements (or no elements for an empty vector).
 
 ```move
 {{#include ../../../packages/samples/sources/move-basics/vector.move:literal}}
@@ -38,8 +37,8 @@ commonly used operations:
 
 ## Destroying a Vector of non-droppable types
 
-A vector of non-droppable types cannot be discarded. If you define a vector of types without the `drop`
-ability, the vector value cannot be ignored. If the vector is empty, the compiler requires an
+A vector of non-droppable types cannot be discarded. If you define a vector of types without the
+`drop` ability, the vector value cannot be ignored. If the vector is empty, the compiler requires an
 explicit call to the `destroy_empty` function.
 
 ```move
@@ -48,6 +47,7 @@ explicit call to the `destroy_empty` function.
 
 The `destroy_empty` function will fail at runtime if you call it on a non-empty vector.
 
-## Further reading
+## Further Reading
 
 - [Vector](/reference/primitive-types/vector.html) in the Move Reference.
+- [std::vector](https://docs.sui.io/references/framework/std/vector) module documentation.

--- a/book/src/object/digital-assets.md
+++ b/book/src/object/digital-assets.md
@@ -47,7 +47,7 @@ assets.
 - Move's asset model mirrors real-world asset management, ensuring secure and accountable asset
   ownership and transfer.
 
-## Further reading
+## Further Reading
 
 - [Move: A Language With Programmable Resources (pdf)](https://developers.diem.com/papers/diem-move-a-language-with-programmable-resources/2019-06-18.pdf)
   by Sam Blackshear, Evan Cheng, David L. Dill, Victor Gao, Ben Maurer, Todd Nowacki, Alistair Pott,

--- a/book/src/object/evolution-of-move.md
+++ b/book/src/object/evolution-of-move.md
@@ -22,6 +22,6 @@ Sui.
 - Sui introduced the Object Model, which provides a native concept of ownership, simplifying asset
   management and enabling heterogeneous collections.
 
-## Further reading
+## Further Reading
 
 - [Why We Created Sui Move](https://blog.sui.io/why-we-created-sui-move/) by Sam Blackshear

--- a/book/src/object/fast-path-and-consensus.md
+++ b/book/src/object/fast-path-and-consensus.md
@@ -33,8 +33,8 @@ need to sequence them.
 ## Consensus Path
 
 Transactions that do access shared state - on Sui it is represented with shared objects - require
-sequencing to ensure that the state is updated and consistent across all nodes. This is known as
-the execution through _consensus_, where transactions accessing shared objects are subject to the
+sequencing to ensure that the state is updated and consistent across all nodes. This is known as the
+execution through _consensus_, where transactions accessing shared objects are subject to the
 agreement process to maintain network consistency.
 
 <!-- On Sui consensus is per-object - mention!!! -->

--- a/book/src/object/object-model.md
+++ b/book/src/object/object-model.md
@@ -44,6 +44,6 @@ Objects in Sui have the following properties:
 - Objects have a type, unique ID, owner, data, version, and digest.
 - The Object Model simplifies asset management and enables a wide range of use cases.
 
-## Further reading
+## Further Reading
 
 - [Object Model](https://docs.sui.io/concepts/object-model) in Sui Documentation.

--- a/book/src/object/ownership.md
+++ b/book/src/object/ownership.md
@@ -4,9 +4,9 @@ Sui introduces four distinct ownership types for objects: single owner, shared s
 shared state, and object-owner. Each model offers unique characteristics and suits different use
 cases, enhancing flexibility and control in object management.
 
-Note that ownership does not control the confidentiality of an object &mdash; it is always
-possible to read the contents of an on-chain object from outside of Move. You should never store
-unencrypted secrets inside of objects.
+Note that ownership does not control the confidentiality of an object &mdash; it is always possible
+to read the contents of an on-chain object from outside of Move. You should never store unencrypted
+secrets inside of objects.
 
 See the [Storage Functions](../storage/storage-functions.md) chapter for details on how to change
 the owner or ownership type of an object.

--- a/book/src/programmability/README.md
+++ b/book/src/programmability/README.md
@@ -1,8 +1,8 @@
 # Advanced Programmability
 
 In previous chapters we've covered [the basics of Move](./../move-basics) and
-[Sui Storage Model](./../storage). Now it's time to dive deeper into the advanced
-topics of Sui programmability.
+[Sui Storage Model](./../storage). Now it's time to dive deeper into the advanced topics of Sui
+programmability.
 
 This chapter introduces more complex concepts, practices and features of Move and Sui that are
 essential for building more sophisticated applications. It is intended for developers who are

--- a/book/src/programmability/bcs.md
+++ b/book/src/programmability/bcs.md
@@ -26,11 +26,13 @@ defined in the struct. The fields are serialized using the same rules as the top
 
 ## Using BCS
 
-The [Sui Framework](./sui-framework.md) includes the sui::bcs module for encoding and decoding data. Encoding functions are native to the VM, and decoding functions are implemented in Move.
+The [Sui Framework](./sui-framework.md) includes the sui::bcs module for encoding and decoding data.
+Encoding functions are native to the VM, and decoding functions are implemented in Move.
 
 ## Encoding
 
-To encode data, use the `bcs::to_bytes` function, which converts data references into byte vectors. This function supports encoding any types, including structs.
+To encode data, use the `bcs::to_bytes` function, which converts data references into byte vectors.
+This function supports encoding any types, including structs.
 
 ```move
 // File: move-stdlib/sources/bcs.move
@@ -54,7 +56,8 @@ Structs encode similarly to simple types. Here is how to encode a struct using B
 
 ## Decoding
 
-Because BCS does not self-describe and Move is statically typed, decoding requires prior knowledge of the data type. The `sui::bcs` module provides various functions to assist with this process.
+Because BCS does not self-describe and Move is statically typed, decoding requires prior knowledge
+of the data type. The `sui::bcs` module provides various functions to assist with this process.
 
 ### Wrapper API
 
@@ -129,4 +132,6 @@ to decode each field manually.
 
 ## Summary
 
-Binary Canonical Serialization is an efficient binary format for structured data, ensuring consistent serialization across platforms. The Sui Framework provides comprehensive tools for working with BCS, allowing extensive functionality through built-in functions.
+Binary Canonical Serialization is an efficient binary format for structured data, ensuring
+consistent serialization across platforms. The Sui Framework provides comprehensive tools for
+working with BCS, allowing extensive functionality through built-in functions.

--- a/book/src/programmability/bcs.md
+++ b/book/src/programmability/bcs.md
@@ -35,7 +35,8 @@ To encode data, use the `bcs::to_bytes` function, which converts data references
 This function supports encoding any types, including structs.
 
 ```move
-// File: move-stdlib/sources/bcs.move
+module std::bcs;
+
 public native fun to_bytes<T>(t: &T): vector<u8>;
 ```
 

--- a/book/src/programmability/capability.md
+++ b/book/src/programmability/capability.md
@@ -8,10 +8,10 @@ owner to perform administrative operations, which regular users cannot.
 
 ## Capability is an Object
 
-In the [Sui Object Model](./../object/), capabilities are represented as objects.
-An owner of an object can pass this object to a function to prove that they have the right to
-perform a specific action. Due to strict typing, the function taking a capability as an argument can
-only be called with the correct capability.
+In the [Sui Object Model](./../object/), capabilities are represented as objects. An owner of an
+object can pass this object to a function to prove that they have the right to perform a specific
+action. Due to strict typing, the function taking a capability as an argument can only be called
+with the correct capability.
 
 > There's a convention to name capabilities with the `Cap` suffix, for example, `AdminCap` or
 > `KioskOwnerCap`.
@@ -29,7 +29,7 @@ application can have a setup phase where the admin account prepares the state of
 {{#include ../../../packages/samples/sources/programmability/capability-2.move:admin_cap}}
 ```
 
-## Address check vs Capability
+## Address Check vs Capability
 
 Utilizing objects as capabilities is a relatively new concept in blockchain programming. And in
 other smart-contract languages, authorization is often performed by checking the address of the

--- a/book/src/programmability/collections.md
+++ b/book/src/programmability/collections.md
@@ -76,5 +76,5 @@ if the two `VecSet` instances contain the same elements.
 
 ## Next Steps
 
-In the next section we will cover the [Wrapper Type Pattern](./wrapper-type-pattern.md) - a design pattern
-often used with collection types to extend or restrict their behavior. 
+In the next section we will cover the [Wrapper Type Pattern](./wrapper-type-pattern.md) - a design
+pattern often used with collection types to extend or restrict their behavior.

--- a/book/src/programmability/collections.md
+++ b/book/src/programmability/collections.md
@@ -19,8 +19,8 @@ application.
 ## VecSet
 
 `VecSet` is a collection type that stores a set of unique items. It is similar to a `vector`, but it
-does not allow duplicate items. This makes it useful for storing a collection of unique items, such
-as a list of unique IDs or addresses.
+does not allow duplicate items. This property makes it useful for storing a collection of unique
+items, such as a list of IDs or addresses.
 
 ```move
 {{#include ../../../packages/samples/sources/programmability/collections-2.move:vec_set}}

--- a/book/src/programmability/display.md
+++ b/book/src/programmability/display.md
@@ -32,8 +32,9 @@ Another important feature of Sui Display is the ability to define templates and 
 those templates. Not only it allows for a more flexible display, but it also frees the developer
 from the need to define the same fields with the same names and types in every object.
 
-> The Object Display is natively supported by the [Sui Full Node](https://docs.sui.io/guides/operator/sui-full-node), and the client can fetch the display
-> metadata for any object if the object type has a Display associated with it.
+> The Object Display is natively supported by the
+> [Sui Full Node](https://docs.sui.io/guides/operator/sui-full-node), and the client can fetch the
+> display metadata for any object if the object type has a Display associated with it.
 
 ```move
 {{#include ../../../packages/samples/sources/programmability/display.move:hero}}

--- a/book/src/programmability/display.md
+++ b/book/src/programmability/display.md
@@ -78,10 +78,10 @@ type it describes. The `fields` of the `Display` object are a `VecMap` of key-va
 key is the field name and the value is the field value. The `version` field is used to version the
 display metadata, and is updated on the `update_display` call.
 
-File: sui-framework/sources/display.move
-
 ```move
-struct Display<phantom T: key> has key, store {
+module sui::display;
+
+public struct Display<phantom T: key> has key, store {
     id: UID,
     /// Contains fields for display. Currently supported
     /// fields are: name, link, image and description.

--- a/book/src/programmability/dynamic-collections.md
+++ b/book/src/programmability/dynamic-collections.md
@@ -45,7 +45,8 @@ that can store any data. Bag will never allow orphaned fields, as it tracks the 
 can't be destroyed if it's not empty.
 
 ```move
-// File: sui-framework/sources/bag.move
+module sui::bag;
+
 public struct Bag has key, store {
     /// the ID of this bag
     id: UID,
@@ -53,6 +54,8 @@ public struct Bag has key, store {
     size: u64,
 }
 ```
+
+_See [full documentation for sui::bag][bag-framework] module._
 
 Due to Bag storing any types, the extra methods it offers is:
 
@@ -81,7 +84,8 @@ Table is a typed dynamic collection that has a fixed type for keys and values. I
 `sui::table` module.
 
 ```move
-// File: sui-framework/sources/table.move
+module sui::table;
+
 public struct Table<phantom K: copy + drop + store, phantom V: store> has key, store {
     /// the ID of this table
     id: UID,
@@ -89,6 +93,8 @@ public struct Table<phantom K: copy + drop + store, phantom V: store> has key, s
     size: u64,
 }
 ```
+
+_See [full documentation for sui::table][table-framework] module._
 
 Used as a struct field:
 
@@ -109,15 +115,27 @@ Defined in the `sui::object_table` module. Identical to [Table](#table), but use
 
 ## Summary
 
-- [Bag](#bag) - a simple collection that can store any type of data
-- [ObjectBag](#objectbag) - a collection that can store only objects
-- [Table](#table) - a typed dynamic collection that has a fixed type for keys and values
-- [ObjectTable](#objecttable) - same as Table, but can only store objects
+- [Bag](#bag) - a simple collection that can store any type of data.
+- [ObjectBag](#objectbag) - a collection that can store only objects.
+- [Table](#table) - a typed dynamic collection that has a fixed type for keys and values.
+- [ObjectTable](#objecttable) - same as Table, but can only store objects.
 <!-- [Linked Table](#linkedtable) -->
 
 ## LinkedTable
 
 This section is coming soon!
+
+## Further Reading
+
+- [sui::table][table-framework] module documentation.
+- [sui::object_table][object-table-framework] module documentation.
+- [sui::bag][bag-framework] module documentation.
+- [sui::object_bag][object-bag-framework] module documentation.
+
+[table-framework]: https://docs.sui.io/references/framework/sui/table
+[object-table-framework]: https://docs.sui.io/references/framework/sui/object_table
+[bag-framework]: https://docs.sui.io/references/framework/sui/bag
+[object-bag-framework]: https://docs.sui.io/references/framework/sui/object_bag
 
 <!-- TODO! -->
 

--- a/book/src/programmability/dynamic-fields.md
+++ b/book/src/programmability/dynamic-fields.md
@@ -19,9 +19,9 @@ Dynamic Fields are defined in the `sui::dynamic_field` module of the
 [Sui Framework](./sui-framework.md). They are attached to object's `UID` via a _name_, and can be
 accessed using that name. There can be only one field with a given name attached to an object.
 
-File: sui-framework/sources/dynamic_field.move
-
 ```move
+module sui::dynamic_field;
+
 /// Internal object used for storing the field and value
 public struct Field<Name: copy + drop + store, Value: store> has key {
     /// Determined by the hash of the object ID, the field name
@@ -120,8 +120,9 @@ As you can see, custom types do work as field names but as long as they can be _
 module, in other words - if they are _internal_ to the module and defined in it. This limitation on
 struct packing can open up new ways in the design of the application.
 
-This approach is used in the Object Capability<!--[]](./object-capability.md)--> pattern, where an application can authorize a
-foreign object to perform operations in it while not exposing the capabilities to other modules.
+This approach is used in the Object Capability<!--[]](./object-capability.md)--> pattern, where an
+application can authorize a foreign object to perform operations in it while not exposing the
+capabilities to other modules.
 
 ## Exposing UID
 

--- a/book/src/programmability/dynamic-object-fields.md
+++ b/book/src/programmability/dynamic-object-fields.md
@@ -20,9 +20,9 @@ combination of `key` and `store`, not just `store` as in the case of dynamic fie
 
 They're less explicit in their framework definition, as the concept itself is more abstract:
 
-File: sui-framework/sources/dynamic_object_fields.move
-
 ```move
+module sui::dynamic_object_field;
+
 /// Internal object used for storing the field and the name associated with the
 /// value. The separate type is necessary to prevent key collision with direct
 /// usage of dynamic_field

--- a/book/src/programmability/epoch-and-time.md
+++ b/book/src/programmability/epoch-and-time.md
@@ -39,7 +39,8 @@ limitation allows parallel access to the `Clock` object, which is important for 
 performance.
 
 ```move
-// File: sui-framework/clock.move
+module sui::clock;
+
 /// Singleton shared object that exposes time to Move calls.  This
 /// object is found at address 0x6, and can only be read (accessed
 /// via an immutable reference) by entry functions.
@@ -48,7 +49,7 @@ performance.
 /// reference or value will fail to verify, and honest validators
 /// will not sign or execute transactions that use `Clock` as an
 /// input parameter, unless it is passed by immutable reference.
-struct Clock has key {
+public struct Clock has key {
     id: UID,
     /// The clock's timestamp, which is set automatically by a
     /// system transaction every time consensus commits a

--- a/book/src/programmability/events.md
+++ b/book/src/programmability/events.md
@@ -6,8 +6,8 @@ on-chain. Events are emitted by the `sui::event` module located in the
 [Sui Framework](./sui-framework.md).
 
 > Any custom type with the [copy](./../move-basics/copy-ability.md) and
-> [drop](./../move-basics/drop-ability.md) abilities can be emitted as an event.
-> Sui Verifier requires the type to be internal to the module.
+> [drop](./../move-basics/drop-ability.md) abilities can be emitted as an event. Sui Verifier
+> requires the type to be internal to the module.
 
 ```move
 // File: sui-framework/sources/event.move

--- a/book/src/programmability/events.md
+++ b/book/src/programmability/events.md
@@ -10,7 +10,6 @@ on-chain. Events are emitted by the `sui::event` module located in the
 > requires the type to be internal to the module.
 
 ```move
-// File: sui-framework/sources/event.move
 module sui::event;
 
 /// Emit a custom Move event, sending the data off-chain.

--- a/book/src/programmability/fast-path.md
+++ b/book/src/programmability/fast-path.md
@@ -23,13 +23,13 @@ Consensus is only required for mutating the shared state. If the object is immut
 as a "constant" and can be accessed in parallel. Frozen objects can be used to share unchangeable
 data between multiple parties without requiring consensus.
 
-## In practice
+## In Practice
 
 ```move
 {{#include ../../../packages/samples/sources/programmability/fast-path.move:main}}
 ```
 
-## Special case: Clock
+## Special Case: Clock
 
 The `Clock` object with the reserved address `0x6` is a special case of a shared object which cannot
 be passed by a mutable reference in a regular transaction. An attempt to do so will not succeed, and

--- a/book/src/programmability/hot-potato-pattern.md
+++ b/book/src/programmability/hot-potato-pattern.md
@@ -75,7 +75,7 @@ lender.repay(pay_back, potato);
 transfer::public_transfer(proceeds, ctx.sender());
 ```
 
-### Variable-path execution
+### Variable-path Execution
 
 The hot potato pattern can be used to introduce variation in the execution path. For example, if
 there is a module which allows purchasing a `Phone` for some "Bonus Points" or for USD, the hot
@@ -105,13 +105,16 @@ will cover in the next section.
 
 The pattern is used in various forms in the Sui Framework. Here are some examples:
 
-- [sui::borrow](https://docs.sui.io/references/framework/sui-framework/borrow) - uses hot potato to
-  ensure that the borrowed value is returned to the correct container.
-- [sui::transfer_policy](https://docs.sui.io/references/framework/sui-framework/transfer_policy) -
-  defines a `TransferRequest` - a hot potato which can only be consumed if all conditions are met.
-- [sui::token](https://docs.sui.io/references/framework/sui-framework/token) - in the Closed Loop
-  Token system, an `ActionRequest` carries the information about the performed action and collects
-  approvals similarly to `TransferRequest`.
+- [sui::borrow][borrow-framework] - uses hot potato to ensure that the borrowed value is returned to
+  the correct container.
+- [sui::transfer_policy][transfer-policy-framework] - defines a `TransferRequest` - a hot potato
+  which can only be consumed if all conditions are met.
+- [sui::token][token-framework] - in the Closed Loop Token system, an `ActionRequest` carries the
+  information about the performed action and collects approvals similarly to `TransferRequest`.
+
+[borrow-framework]: https://docs.sui.io/references/framework/sui-framework/borrow
+[transfer-policy-framework]: https://docs.sui.io/references/framework/sui-framework/transfer_policy
+[token-framework]: https://docs.sui.io/references/framework/sui-framework/token
 
 ## Summary
 

--- a/book/src/programmability/module-initializer.md
+++ b/book/src/programmability/module-initializer.md
@@ -6,8 +6,8 @@ publication. In Sui, this is achieved by defining an `init` function within the 
 function will automatically be called when the module is published.
 
 > All of the modules' `init` functions are called during the publishing process. Currently, this
-> behavior is limited to the publish command and does not extend to
-> package upgrades. <!-- [package upgrades](./package-upgrades.md) -->
+> behavior is limited to the publish command and does not extend to package upgrades.
+> <!-- [package upgrades](./package-upgrades.md) -->
 
 ```move
 {{#include ../../../packages/samples/sources/programmability/module-initializer.move:main}}
@@ -19,7 +19,7 @@ In the same package, another module can have its own `init` function, encapsulat
 {{#include ../../../packages/samples/sources/programmability/module-initializer-2.move:other}}
 ```
 
-## `init` features
+## `init` Features
 
 The function is called on publish, if it is present in the module and follows the rules:
 
@@ -41,7 +41,7 @@ fun init(ctx: &TxContext) { /* ... */}
 fun init(otw: OTW, ctx: &TxContext) { /* ... */ }
 ```
 
-## Trust and security
+## Trust and Security
 
 While `init` function can be used to create sensitive objects once, it is important to know that the
 same object (eg. `StoreOwnerCap` from the first example) can still be created in another function.
@@ -53,7 +53,7 @@ There are ways to guarantee that the object was created only once, such as the
 [One Time Witness](./one-time-witness.md). And there are ways to limit or disable the upgrade of the
 module, which we will cover in the [Package Upgrades](./package-upgrades.md) chapter.
 
-## Next steps
+## Next Steps
 
 As follows from the definition, the `init` function is guaranteed to be called only once when the
 module is published. So it is a good place to put the code that initializes module's objects and

--- a/book/src/programmability/module-initializer.md
+++ b/book/src/programmability/module-initializer.md
@@ -7,6 +7,7 @@ function will automatically be called when the module is published.
 
 > All of the modules' `init` functions are called during the publishing process. Currently, this
 > behavior is limited to the publish command and does not extend to package upgrades.
+>
 > <!-- [package upgrades](./package-upgrades.md) -->
 
 ```move

--- a/book/src/programmability/one-time-witness.md
+++ b/book/src/programmability/one-time-witness.md
@@ -13,8 +13,9 @@ Notes to self:
 
 ## Definition
 
-The OTW is a special type of Witness that can be used only once. It cannot be manually
-created and it is guaranteed to be unique per module. Sui Adapter treats a type as an OTW if it follows these rules:
+The OTW is a special type of Witness that can be used only once. It cannot be manually created and
+it is guaranteed to be unique per module. Sui Adapter treats a type as an OTW if it follows these
+rules:
 
 1. Has only `drop` ability.
 2. Has no fields.
@@ -27,16 +28,15 @@ Here is an example of an OTW:
 {{#include ../../../packages/samples/sources/programmability/one-time-witness.move:definition}}
 ```
 
-The OTW cannot be constructed manually, and any code attempting to do so will result in
-a compilation error. The OTW can be received as the first argument in the
+The OTW cannot be constructed manually, and any code attempting to do so will result in a
+compilation error. The OTW can be received as the first argument in the
 [module initializer](./module-initializer.md). And because the `init` function is called only once
 per module, the OTW is guaranteed to be instantiated only once.
 
 ## Enforcing the OTW
 
-To check if a type is an OTW, `sui::types` module of the
-[Sui Framework](./sui-framework.md) offers a special function `is_one_time_witness` that can be used
-to check if the type is an OTW.
+To check if a type is an OTW, `sui::types` module of the [Sui Framework](./sui-framework.md) offers
+a special function `is_one_time_witness` that can be used to check if the type is an OTW.
 
 ```move
 {{#include ../../../packages/samples/sources/programmability/one-time-witness.move:usage}}
@@ -140,14 +140,14 @@ TODO: add a story behind TreasuryCap and Coin
 
 ## Summary
 
-The OTW pattern is a great way to ensure that a type is used only once. Most of the
-developers should understand how to define and receive the OTW, while the OTW checks and enforcement
-is mostly needed in libraries and frameworks. For example, the `sui::coin` module requires an OTW
-in the `coin::create_currency` method, therefore enforcing that the `coin::TreasuryCap`
-is created only once.
+The OTW pattern is a great way to ensure that a type is used only once. Most of the developers
+should understand how to define and receive the OTW, while the OTW checks and enforcement is mostly
+needed in libraries and frameworks. For example, the `sui::coin` module requires an OTW in the
+`coin::create_currency` method, therefore enforcing that the `coin::TreasuryCap` is created only
+once.
 
-OTW is a powerful tool that lays the foundation for the [Publisher](./publisher.md)
-object, which we will cover in the next section.
+OTW is a powerful tool that lays the foundation for the [Publisher](./publisher.md) object, which we
+will cover in the next section.
 
 <!--
 

--- a/book/src/programmability/publisher.md
+++ b/book/src/programmability/publisher.md
@@ -14,7 +14,8 @@ and is used to prove the authority of the publisher over a type. To claim a Publ
 publisher must present a [One Time Witness](./one-time-witness.md) to the `package::claim` function.
 
 ```move
-// File: sui-framework/sources/package.move
+module sui::package;
+
 public struct Publisher has key, store {
     id: UID,
     package: String,

--- a/book/src/programmability/publisher.md
+++ b/book/src/programmability/publisher.md
@@ -51,10 +51,10 @@ system configurations, it can also be used to manage the application's state.
 ```
 
 However, Publisher misses some native properties of [Capabilities](./capability.md), such as type
-safety and expressiveness. The signature for the `admin_action` is not very explicit, can be
-called by anyone else. And due to `Publisher` object being standard, there now is a risk of
-unauthorized access if the `from_module` check is not performed. So it's important to be cautious
-when using the `Publisher` object as an admin role.
+safety and expressiveness. The signature for the `admin_action` is not very explicit, can be called
+by anyone else. And due to `Publisher` object being standard, there now is a risk of unauthorized
+access if the `from_module` check is not performed. So it's important to be cautious when using the
+`Publisher` object as an admin role.
 
 ## Role on Sui
 

--- a/book/src/programmability/sui-framework.md
+++ b/book/src/programmability/sui-framework.md
@@ -12,8 +12,8 @@ still part of the same framework._
 <!-- Custom CSS addition in the theme/custom.css  -->
 <div class="modules-table">
 
-| Module                                                                                                   | Description                                                                | Chapter                                                                |
-| -------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
+| Module                                                                                         | Description                                                                | Chapter                                                                |
+| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
 | [sui::address](https://docs.sui.io/references/framework/sui/address)                           | Adds conversion methods to the [address type](./../move-basics/address.md) | [Address](./../move-basics/address.md)                                 |
 | [sui::transfer](https://docs.sui.io/references/framework/sui/transfer)                         | Implements the storage operations for Objects                              | [It starts with an Object](./../object)                                |
 | [sui::tx_context](https://docs.sui.io/references/framework/sui/tx_context)                     | Contains the `TxContext` struct and methods to read it                     | [Transaction Context](./transaction-context.md)                        |
@@ -31,8 +31,8 @@ still part of the same framework._
 
 <div class="modules-table">
 
-| Module                                                                                   | Description                                                       | Chapter                                         |
-| ---------------------------------------------------------------------------------------- | ----------------------------------------------------------------- | ----------------------------------------------- |
+| Module                                                                         | Description                                                       | Chapter                                         |
+| ------------------------------------------------------------------------------ | ----------------------------------------------------------------- | ----------------------------------------------- |
 | [sui::vec_set](https://docs.sui.io/references/framework/sui/vec_set)           | Implements a set type                                             | [Collections](./collections.md)                 |
 | [sui::vec_map](https://docs.sui.io/references/framework/sui/vec_map)           | Implements a map with vector keys                                 | [Collections](./collections.md)                 |
 | [sui::table](https://docs.sui.io/references/framework/sui/table)               | Implements the `Table` type and methods to interact with it       | [Dynamic Collections](./dynamic-collections.md) |
@@ -47,8 +47,8 @@ still part of the same framework._
 
 <div class="modules-table">
 
-| Module                                                                       | Description                                                | Chapter                                    |
-| ---------------------------------------------------------------------------- | ---------------------------------------------------------- | ------------------------------------------ |
+| Module                                                             | Description                                                | Chapter                                    |
+| ------------------------------------------------------------------ | ---------------------------------------------------------- | ------------------------------------------ |
 | [sui::bcs](https://docs.sui.io/references/framework/sui/bcs)       | Implements the BCS encoding and decoding functions         | [Binary Canonical Serialization](./bcs.md) |
 | [sui::borrow](https://docs.sui.io/references/framework/sui/borrow) | Implements the borrowing mechanic for borrowing by _value_ | [Hot Potato](./hot-potato-pattern.md)      |
 | [sui::hex](https://docs.sui.io/references/framework/sui/hex)       | Implements the hex encoding and decoding functions         | -                                          |

--- a/book/src/programmability/transaction-context.md
+++ b/book/src/programmability/transaction-context.md
@@ -68,6 +68,8 @@ available in the `sui::tx_context` module. It may be useful if you need to gener
 identifier in your program.
 
 ```move
+module sui::tx_context;
+
 /// Create an `address` that has not been used. As it is an object address, it will never
 /// occur as the address for a user.
 /// In other words, the generated address is a globally unique object ID.

--- a/book/src/programmability/transaction-context.md
+++ b/book/src/programmability/transaction-context.md
@@ -5,14 +5,17 @@ available to the program during execution. For example, every transaction has a 
 the transaction context contains a variable that holds the sender address.
 
 The transaction context is available to the program through the `TxContext` struct. The struct is
-defined in the `sui::tx_context` module and contains the following fields:
+defined in the [`sui::tx_context`][tx-context-framework] module and contains the following fields:
+
+[tx-context-framework]: https://docs.sui.io/references/framework/sui/tx_context
 
 ```move
-// File: sui-framework/sources/tx_context.move
+module sui::tx_context;
+
 /// Information about the transaction currently being executed.
 /// This cannot be constructed by a transaction--it is a privileged object created by
 /// the VM and passed in to the entrypoint of the transaction as `&mut TxContext`.
-struct TxContext has drop {
+public struct TxContext has drop {
     /// The address of the user that signed the current transaction
     sender: address,
     /// Hash of the current transaction
@@ -54,11 +57,10 @@ parameter. Sui uses the `ids_created` field for that. Every time a new UID is cr
 Internally, it is represented as the `derive_id` function:
 
 ```move
-// File: sui-framework/sources/tx_context.move
 native fun derive_id(tx_hash: vector<u8>, ids_created: u64): address;
 ```
 
-## Generating unique addresses
+## Generating Unique Addresses
 
 The underlying `derive_id` function can also be utilized in your program to generate unique
 addresses. The function itself is not exposed, but a wrapper function `fresh_object_address` is
@@ -66,7 +68,6 @@ available in the `sui::tx_context` module. It may be useful if you need to gener
 identifier in your program.
 
 ```move
-// File: sui-framework/sources/tx_context.move
 /// Create an `address` that has not been used. As it is an object address, it will never
 /// occur as the address for a user.
 /// In other words, the generated address is a globally unique object ID.

--- a/book/src/programmability/witness-pattern.md
+++ b/book/src/programmability/witness-pattern.md
@@ -48,8 +48,8 @@ public fun new_instance(): Instance<W> {
 }
 ```
 
-The instance of the struct `W` is passed into the `new_instance` function to create an `Instance<W>`, thereby
-proving that the module `book::witness_source` owns the type `W`.
+The instance of the struct `W` is passed into the `new_instance` function to create an
+`Instance<W>`, thereby proving that the module `book::witness_source` owns the type `W`.
 
 ## Instantiating a Generic Type
 
@@ -58,7 +58,8 @@ associated behaviors from the type with an option to extend them, if the module 
 to do so.
 
 ```move
-// File: sui-framework/sources/balance.move
+module sui::balance;
+
 /// A Supply of T. Used for minting and burning.
 public struct Supply<phantom T> has store {
     value: u64,
@@ -75,16 +76,19 @@ public fun supply_value<T>(supply: &Supply<T>): u64 {
 }
 ```
 
-In the example above, which is borrowed from the `balance` module of the
+In the example above, which is borrowed from the [`balance` module][balance-framework] of the
 [Sui Framework](./sui-framework.md), the `Supply` a generic struct that can be constructed only by
 supplying a witness of the type `T`. The witness is taken by value and _discarded_ - hence the `T`
 must have the [drop](./../move-basics/drop-ability.md) ability.
+
+[balance-framework]: https://docs.sui.io/references/framework/sui/balance
 
 The instantiated `Supply<T>` can then be used to mint new `Balance<T>`'s, where `T` is the type of
 the supply.
 
 ```move
-// File: sui-framework/sources/balance.move
+module sui::balance;
+
 /// Storable balance.
 public struct Balance<phantom T> has store {
     value: u64,

--- a/book/src/programmability/wrapper-type-pattern.md
+++ b/book/src/programmability/wrapper-type-pattern.md
@@ -50,8 +50,8 @@ extend the behavior of an existing type. However, it does have some limitations:
 
 ## Next Steps
 
-The wrapper type pattern is very useful, particularly when used in conjunction with collection types, as
-demonstrated in the previous section. In the next section, we will cover
+The wrapper type pattern is very useful, particularly when used in conjunction with collection
+types, as demonstrated in the previous section. In the next section, we will cover
 [Dynamic Fields](./dynamic-fields.md) — an important primitive that enables
 [Dynamic Collections](./dynamic-collections.md), a way to store large collections of data in a more
 flexible, albeit more expensive, way.

--- a/book/src/storage/key-ability.md
+++ b/book/src/storage/key-ability.md
@@ -1,9 +1,9 @@
 # The Key Ability
 
 In the [Basic Syntax](./../move-basics) chapter we already covered two out of four abilities -
-[Drop](./../move-basics/drop-ability.md) and [Copy](./../move-basics/copy-ability.md). They affect the behavior of the value in a
-scope and are not directly related to storage. It is time to cover the `key` ability, which allows
-the struct to be stored.
+[Drop](./../move-basics/drop-ability.md) and [Copy](./../move-basics/copy-ability.md). They affect
+the behavior of the value in a scope and are not directly related to storage. It is time to cover
+the `key` ability, which allows the struct to be stored.
 
 Historically, the `key` ability was created to mark the type as a _key in the storage_. A type with
 the `key` ability could be stored at top-level in the storage, and could be _directly owned_ by an
@@ -57,6 +57,6 @@ custom types.
 Key ability defines the object in Move, and objects are intended to be _stored_. In the next section
 we present the `sui::transfer` module, which provides native storage functions for objects.
 
-## Further reading
+## Further Reading
 
 - [Type Abilities](/reference/abilities.html) in the Move Reference.

--- a/book/src/storage/storage-functions.md
+++ b/book/src/storage/storage-functions.md
@@ -21,7 +21,7 @@ The `transfer` module provides functions to perform all three storage operations
 The `transfer` module is a go-to for most of the storage operations, except a special case with
 [Dynamic Fields](./../programmability/dynamic-fields.md) that awaits us in the next chapter.
 
-## Ownership and References: A Quick Recap
+## Ownership and References: a Quick Recap
 
 In the [Ownership and Scope](./../move-basics/ownership-and-scope.md) and
 [References](./../move-basics/references.md) chapters, we covered the basics of ownership and
@@ -138,9 +138,9 @@ A quick recap:
 
 ## Freeze
 
-The `transfer::freeze_object` function is a public function that is used to put
-an object into an _immutable_ state. Once an object is _frozen_, it can never
-be changed, and it can be accessed by anyone by immutable reference.
+The `transfer::freeze_object` function is a public function that is used to put an object into an
+_immutable_ state. Once an object is _frozen_, it can never be changed, and it can be accessed by
+anyone by immutable reference.
 
 The function signature is as follows, only accepts a type with the
 [`key` ability](./key-ability.md). Just like all other storage functions, it takes the object _by

--- a/book/src/storage/storage-functions.md
+++ b/book/src/storage/storage-functions.md
@@ -61,7 +61,8 @@ passed into the function _by value_, therefore it is _moved_ to the function sco
 the recipient address:
 
 ```move
-// File: sui-framework/sources/transfer.move
+module sui::transfer;
+
 public fun transfer<T: key>(obj: T, recipient: address);
 ```
 
@@ -69,28 +70,27 @@ In the next example, you can see how it can be used in a module that defines and
 the transaction sender.
 
 ```move
-module book::transfer_to_sender {
+module book::transfer_to_sender;
 
-    /// A struct with `key` is an object. The first field is `id: UID`!
-    public struct AdminCap has key { id: UID }
+/// A struct with `key` is an object. The first field is `id: UID`!
+public struct AdminCap has key { id: UID }
 
-    /// `init` function is a special function that is called when the module
-    /// is published. It is a good place to create application objects.
-    fun init(ctx: &mut TxContext) {
-        // Create a new `AdminCap` object, in this scope.
-        let admin_cap = AdminCap { id: object::new(ctx) };
+/// `init` function is a special function that is called when the module
+/// is published. It is a good place to create application objects.
+fun init(ctx: &mut TxContext) {
+    // Create a new `AdminCap` object, in this scope.
+    let admin_cap = AdminCap { id: object::new(ctx) };
 
-        // Transfer the object to the transaction sender.
-        transfer::transfer(admin_cap, ctx.sender());
+    // Transfer the object to the transaction sender.
+    transfer::transfer(admin_cap, ctx.sender());
 
-        // admin_cap is gone! Can't be accessed anymore.
-    }
+    // admin_cap is gone! Can't be accessed anymore.
+}
 
-    /// Transfers the `AdminCap` object to the `recipient`. Thus, the recipient
-    /// becomes the owner of the object, and only they can access it.
-    public fun transfer_admin_cap(cap: AdminCap, recipient: address) {
-        transfer::transfer(cap, recipient);
-    }
+/// Transfers the `AdminCap` object to the `recipient`. Thus, the recipient
+/// becomes the owner of the object, and only they can access it.
+public fun transfer_admin_cap(cap: AdminCap, recipient: address) {
+    transfer::transfer(cap, recipient);
 }
 ```
 
@@ -147,7 +147,8 @@ The function signature is as follows, only accepts a type with the
 value_:
 
 ```move
-// File: sui-framework/sources/transfer.move
+module sui::transfer;
+
 public fun freeze_object<T: key>(obj: T);
 ```
 
@@ -240,7 +241,8 @@ immutable too). The function signature is as follows, only accepts a type with t
 [`key` ability](./key-ability.md):
 
 ```move
-// File: sui-framework/sources/transfer.move
+module sui::transfer;
+
 public fun share_object<T: key>(obj: T);
 ```
 

--- a/book/src/storage/store-ability.md
+++ b/book/src/storage/store-ability.md
@@ -50,6 +50,6 @@ All of the types defined in the standard library have the `store` ability as wel
 - [String](./../move-basics/string.md)
 - [TypeName](./../move-basics/type-reflection.md#typename)
 
-## Further reading
+## Further Reading
 
 - [Type Abilities](/reference/abilities.html) in the Move Reference.

--- a/book/src/storage/transfer-restrictions.md
+++ b/book/src/storage/transfer-restrictions.md
@@ -16,7 +16,8 @@ The `sui::transfer` module provides the following public functions. They are alm
 ones we already covered, but can be called from any module.
 
 ```move
-// File: sui-framework/sources/transfer.move
+module sui::transfer;
+
 /// Public version of the `transfer` function.
 public fun public_transfer<T: key + store>(object: T, to: address) {}
 

--- a/book/src/storage/transfer-restrictions.md
+++ b/book/src/storage/transfer-restrictions.md
@@ -42,11 +42,12 @@ module book::transfer_a;
 public struct ObjectK has key { id: UID }
 public struct ObjectKS has key, store { id: UID }
 ```
+
 ```move
 /// Imports the `ObjectK` and `ObjectKS` types from `transfer_a` and attempts
 /// to implement different `transfer` functions for them
 module book::transfer_b;
-    
+
 // types are not internal to this module
 use book::transfer_a::{ObjectK, ObjectKS};
 

--- a/book/src/storage/uid-and-id.md
+++ b/book/src/storage/uid-and-id.md
@@ -19,7 +19,7 @@ public struct ID has store, drop {
 
 <!-- User doesn't know anything about TxContext yet... -->
 
-## Fresh UID generation:
+## Fresh UID Generation:
 
 - UID is derived from the `tx_hash` and an `index` which is incremented for each new UID.
 - The `derive_id` function is implemented in the `sui::tx_context` module, and that is why TxContext
@@ -36,11 +36,12 @@ let uid = object::new(ctx);
 ```
 
 On Sui, `UID` acts as a representation of an object, and allows defining behaviors and features of
-an object. One of the key features - [Dynamic Fields](../programmability/dynamic-fields.html) - is possible because of the `UID` type
-being explicit. Additionally, it allows the [Transfer to Object (TTO)](https://docs.sui.io/concepts/transfers/transfer-to-object), which we will explain later
-in this chapter.
+an object. One of the key features - [Dynamic Fields](../programmability/dynamic-fields.html) - is
+possible because of the `UID` type being explicit. Additionally, it allows the
+[Transfer to Object (TTO)](https://docs.sui.io/concepts/transfers/transfer-to-object), which we will
+explain later in this chapter.
 
-## UID lifecycle
+## UID Lifecycle
 
 The `UID` type is created with the `object::new(ctx)` function, and it is destroyed with the
 `object::delete(uid)` function. The `object::delete` consumes the UID _by value_, and it is

--- a/book/src/storage/uid-and-id.md
+++ b/book/src/storage/uid-and-id.md
@@ -5,7 +5,8 @@ turn, wraps the `address` type. The UIDs on Sui are guaranteed to be unique, and
 after the object was deleted.
 
 ```move
-// File: sui-framework/sources/object.move
+module sui::object;
+
 /// UID is a unique identifier of an object
 public struct UID has store {
     id: ID

--- a/book/src/your-first-move/hello-sui.md
+++ b/book/src/your-first-move/hello-sui.md
@@ -53,7 +53,7 @@ There are not many other reasons for the code to fail at this stage. But if you 
 issues, try looking up the structure of the package in
 [this location](https://github.com/MystenLabs/move-book/tree/main/packages/todo_list).
 
-## Set up an Account
+## Set Up an Account
 
 > If you already have an account set up, you can skip this step.
 

--- a/book/src/your-first-move/hello-sui.md
+++ b/book/src/your-first-move/hello-sui.md
@@ -14,7 +14,7 @@ Following the same flow as in [Hello, World!](./hello-world.md), we will create 
 $ sui move new todo_list
 ```
 
-## Add the code
+## Add the Code
 
 To speed things up and focus on the application logic, we will provide the code for the todo list
 application. Replace the contents of the _sources/todo_list.move_ file with the following code:
@@ -26,7 +26,7 @@ application. Replace the contents of the _sources/todo_list.move_ file with the 
 {{#include ../../../packages/todo_list/sources/todo_list.move:all}}
 ```
 
-## Build the package
+## Build the Package
 
 To make sure that we did everything correctly, let's build the package by running the
 `sui move build` command. If everything is correct, you should see the output similar to the
@@ -53,12 +53,16 @@ There are not many other reasons for the code to fail at this stage. But if you 
 issues, try looking up the structure of the package in
 [this location](https://github.com/MystenLabs/move-book/tree/main/packages/todo_list).
 
+## Set up an Account
 
-## Set up an account
 > If you already have an account set up, you can skip this step.
 
 To publish and interact with the package, we need to set up an account. While developing, the best
-option for doing so is to run your own [Local Network](https://docs.sui.io/guides/developer/getting-started/local-network). For now you just need to run `RUST_LOG="off,sui_node=info" sui start --with-faucet --force-regenesis`. The Sui Local Network will run on port 9000 of your machine, so make sure that the port isn’t being used by any other application.
+option for doing so is to run your own
+[Local Network](https://docs.sui.io/guides/developer/getting-started/local-network). For now you
+just need to run `RUST_LOG="off,sui_node=info" sui start --with-faucet --force-regenesis`. The Sui
+Local Network will run on port 9000 of your machine, so make sure that the port isn’t being used by
+any other application.
 
 If you are doing it for the first time, you will need to create a new account. To do this, run the
 `sui client` command, then the CLI will prompt you with multiple questions. The answers are marked

--- a/book/src/your-first-move/hello-world.md
+++ b/book/src/your-first-move/hello-world.md
@@ -106,8 +106,8 @@ with the `#[test]` attribute. Tests can be grouped in a separate module (then it
 _module_name_tests.move_), or inside the module they're testing.
 
 Modules, imports, constants and functions can be annotated with `#[test_only]`. This attribute is
-used to exclude modules, functions or imports from the build process. This is useful when you want to
-add helpers for your tests without including them in the code that will be published on chain.
+used to exclude modules, functions or imports from the build process. This is useful when you want
+to add helpers for your tests without including them in the code that will be published on chain.
 
 The _hello_world_tests.move_ file contains a commented out test module template:
 

--- a/packages/samples/sources/move-basics/assert-and-abort.move
+++ b/packages/samples/sources/move-basics/assert-and-abort.move
@@ -3,20 +3,15 @@
 
 module book::assert_abort;
 
-#[test, expected_failure(abort_code = 1, location=Self)]
+#[test, expected_failure(abort_code = 0, location=Self)]
 fun test_abort() {
 
 // ANCHOR: abort
 let user_has_access = true;
 
 // abort with a predefined constant if `user_has_access` is false
-if (!user_has_access) {
-    abort 0
-};
-
-// there's an alternative syntax using parenthesis`
 if (user_has_access) {
-   abort(1)
+    abort 0
 };
 // ANCHOR_END: abort
 }

--- a/packages/samples/sources/move-basics/enum-and-match-2.move
+++ b/packages/samples/sources/move-basics/enum-and-match-2.move
@@ -1,7 +1,8 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-// note that the module has changed!
+// ANCHOR: enum_test
+// Note, that the module has changed!
 module book::segment_tests;
 
 use book::segment;
@@ -9,7 +10,7 @@ use std::unit_test::assert_eq;
 
 #[test]
 fun test_full_enum_cycle() {
-    // create a vector of different Segment variants
+    // Create a vector of different Segment variants.
     let segments = vector[
         segment::new_empty(),
         segment::new_string(b"hello".to_string()),
@@ -18,15 +19,16 @@ fun test_full_enum_cycle() {
         segment::new_special(b"21", 1), // hex
     ];
 
-    // aggregate all segments into the final string using `vector::fold!` macro
+    // Aggregate all segments into the final string using `vector::fold!` macro.
     let result = segments.fold!(b"".to_string(), |mut acc, segment| {
-        // do not append empty, only `Special` and `String`
+        // Do not append empty, only `Special` and `String`.
         if (!segment.is_empty()) {
             acc.append(segment.to_string());
         };
         acc
     });
 
-    // check that the result is what's expected
+    // Check that the result is what's expected.
     assert_eq!(result, b"hello move!".to_string());
 }
+// ANCHOR_END: enum_test

--- a/packages/samples/sources/move-basics/enum-and-match.move
+++ b/packages/samples/sources/move-basics/enum-and-match.move
@@ -1,23 +1,27 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+// ANCHOR: definition
 module book::segment;
 
 use std::string::String;
 
 /// `Segment` enum definition.
-public enum Segment has drop, copy {
-    /// Empty variant, no value
+/// Defines various string segments.
+public enum Segment has copy, drop {
+    /// Empty variant, no value.
     Empty,
-    /// Variant with a value (positional style)
+    /// Variant with a value (positional style).
     String(String),
-    /// Variant with named fields
+    /// Variant with named fields.
     Special {
         content: vector<u8>,
-        encoding: u8, // Encoding tag
-    }
+        encoding: u8, // Encoding tag.
+    },
 }
+// ANCHOR_END: definition
 
+// ANCHOR: constructors
 /// Constructs an `Empty` segment.
 public fun new_empty(): Segment { Segment::Empty }
 
@@ -31,9 +35,11 @@ public fun new_special(content: vector<u8>, encoding: u8): Segment {
         encoding,
     }
 }
+// ANCHOR_END: constructors
 
+// ANCHOR: struct
 /// A struct to demonstrate enum capabilities.
-public struct Segments(vector<Segment>) has drop, copy;
+public struct Segments(vector<Segment>) has copy, drop;
 
 #[test]
 fun test_segments() {
@@ -44,24 +50,30 @@ fun test_segments() {
         Segment::Special { content: b"21", encoding: 1 },
     ]);
 }
+// ANCHOR_END: struct
 
+// ANCHOR: is_empty
 /// Whether this it's an `Empty` segment.
-public fun is_empty_(s: &Segment): bool {
-    // Match is an expression, hence we can use it for return value
+public fun is_empty(s: &Segment): bool {
+    // Match is an expression, hence we can use it for return value.
     match (s) {
         Segment::Empty => true,
         Segment::String(_str) => false,
-        Segment::Special { content: _, encoding: _ } => false
+        Segment::Special { content: _, encoding: _ } => false,
     }
 }
+// ANCHOR_END: is_empty
 
-public fun is_empty(s: &Segment): bool {
+public fun is_empty_(s: &Segment): bool {
+    // ANCHOR: is_empty_2
     match (s) {
         Segment::Empty => true,
-        _ => false, // Anything else returns `false`
+        _ => false, // Anything else returns `false`.
     }
 }
+// ANCHOR_END: is_empty_2
 
+// ANCHOR: accessors
 /// Whether it's a `Special` segment.
 public fun is_special(s: &Segment): bool {
     match (s) {
@@ -78,15 +90,19 @@ public fun is_string(s: &Segment): bool {
         _ => false,
     }
 }
+// ANCHOR_END: accessors
 
+// ANCHOR: try_into_inner_string
 /// Returns `Some(String)` if the `Segment` is `String`, `None` otherwise.
 public fun try_into_inner_string(s: Segment): Option<String> {
     match (s) {
         Segment::String(str) => option::some(str),
-        _ => option::none()
+        _ => option::none(),
     }
 }
+// ANCHOR_END: try_into_inner_string
 
+// ANCHOR: to_string
 /// Return a `String` representation of a segment.
 public fun to_string(s: &Segment): String {
     match (*s) {
@@ -96,15 +112,16 @@ public fun to_string(s: &Segment): String {
         Segment::String(str) => str,
         // Return the decoded contents based on the encoding.
         Segment::Special { content, encoding } => {
-            // Perform a match on the encoding, we only support 0 - ut8, 1 - hex
+            // Perform a match on the encoding, we only support 0 - ut8, 1 - hex.
             match (encoding) {
-                // Plain encoding, return content
+                // Plain encoding, return content.
                 0 => content.to_string(),
-                // HEX encoding, decode and return
+                // HEX encoding, decode and return.
                 1 => sui::hex::decode(content).to_string(),
-                // We have to provide a wildcard pattern, because values of `u8` are 0-255
-                _ => abort
+                // We have to provide a wildcard pattern, because values of `u8` are 0-255.
+                _ => abort,
             }
-        }
+        },
     }
 }
+// ANCHOR_END: to_string

--- a/packages/samples/sources/move-basics/enum-and-match.move
+++ b/packages/samples/sources/move-basics/enum-and-match.move
@@ -53,7 +53,7 @@ fun test_segments() {
 // ANCHOR_END: struct
 
 // ANCHOR: is_empty
-/// Whether this it's an `Empty` segment.
+/// Whether this is an `Empty` segment.
 public fun is_empty(s: &Segment): bool {
     // Match is an expression, hence we can use it for return value.
     match (s) {
@@ -74,7 +74,7 @@ public fun is_empty_(s: &Segment): bool {
 // ANCHOR_END: is_empty_2
 
 // ANCHOR: accessors
-/// Whether it's a `Special` segment.
+/// Whether this is a `Special` segment.
 public fun is_special(s: &Segment): bool {
     match (s) {
         // Hint: the `..` ignores inner fields
@@ -83,7 +83,7 @@ public fun is_special(s: &Segment): bool {
     }
 }
 
-/// Whether it's a `String` segment.
+/// Whether this is a `String` segment.
 public fun is_string(s: &Segment): bool {
     match (s) {
         Segment::String(_) => true,


### PR DESCRIPTION
- fixes samples in the enums chapter - uses Move files instead of inline code
- removes `File: ...`, replaces with module label for std / framework
- adds links to std / framework docs where relevant
- fixes a few old mistakes in inline code
- Capitalize Every Header
- runs the formatter on all of the codebase (I will create a CI for that in a follow up)

UPD: copilot did a nice summary of the changes!