### PR TITLE
Nitpick at dynamic fields example

### DIFF
--- a/packages/samples/sources/programmability/dynamic-fields.move
+++ b/packages/samples/sources/programmability/dynamic-fields.move
@@ -15,9 +15,9 @@ public struct Character has key {
 }
 
 // List of different accessories that can be attached to a character.
-// They must have the `store` ability.
+// They must have the `store` ability, but they do NOT need to have the `key` ability.
 public struct Hat has key, store { id: UID, color: u32 }
-public struct Mustache has key, store { id: UID }
+public struct Mustache has store { id: UID }
 
 #[test]
 fun test_character_and_accessories() {


### PR DESCRIPTION
Since that's the main difference between objects stored as df and objects stored as dof is that the former do not need to have the key ability, I believe is worth clarifying that on the example, or at least not having both objects that are gonna be used for df having `key`.