### PR TITLE
fix(book): Replace incorrect ctx variable in guides

### DIFF
--- a/book/src/guides/code-quality-checklist.md
+++ b/book/src/guides/code-quality-checklist.md
@@ -497,7 +497,7 @@ test.end();
 
 // good! there's a dummy context for simple cases
 let ctx = &mut tx_context::dummy();
-app::mint(test.ctx()).destroy();
+app::mint(ctx).destroy();
 ```
 
 ### Do Not Use Abort Codes in `assert!` in Tests


### PR DESCRIPTION
The `good` code still used the `bad` ctx variable in the `Do Not Use TestScenario Where Not Necessary` example.