### PR TITLE
fix(docs): correct abort code in "Aborting Execution" section

### DIFF
--- a/book/src/move-basics/assert-and-abort.md
+++ b/book/src/move-basics/assert-and-abort.md
@@ -38,7 +38,7 @@ an abort code, which is returned to the caller of the transaction. The abort cod
 {{#include ../../../packages/samples/sources/move-basics/assert-and-abort.move:abort}}
 ```
 
-The code above will, of course, abort with abort code `1`.
+The code above will, of course, abort with abort code `0`.
 
 ## assert!
 


### PR DESCRIPTION
Corrected the description of the example abort statement to reflect that it aborts with code 0, not 1. This change ensures the documentation aligns with the actual behavior shown in the code snippet.