### PR TITLE
chore: remove redundant words in comment

### DIFF
--- a/reference/control-flow/pattern-matching.md
+++ b/reference/control-flow/pattern-matching.md
@@ -577,7 +577,7 @@ mut_on_value(x); // returns 3
 ### `..` Usage
 
 The `..` pattern can only be used within a constructor pattern as a wildcard that matches any number
-of fields -- the the compiler expands the `..` to inserting `_` in any missing fields in the
+of fields -- the compiler expands the `..` to inserting `_` in any missing fields in the
 constructor pattern (if any). So `MyStruct(_, _, _)` is the same as `MyStruct(..)`,
 `MyStruct(1, _, _)` is the same as `MyStruct(1, ..)`. Because of this, there are some restrictions
 on how, and where the `..` pattern can be used:

--- a/reference/functions.md
+++ b/reference/functions.md
@@ -363,7 +363,7 @@ fun add(x: u64, y: u64): u64 {
 The return value here is the result of `x + y`.
 
 [As mentioned above](#function-body), the function's body is an [expression block](./variables). The
-expression block can sequence various statements, and the final expression in the block will be be
+expression block can sequence various statements, and the final expression in the block will be
 the value of that block
 
 ```move


### PR DESCRIPTION
remove redundant words in comment