### PR TITLE
[reference] Fix code errors

### DIFF
--- a/reference/abort-and-assert.md
+++ b/reference/abort-and-assert.md
@@ -54,7 +54,7 @@ that all numbers in the vector are less than the specified `bound`. And aborts o
 ```move
 use std::vector;
 fun check_vec(v: &vector<u64>, bound: u64) {
-    let i = 0;
+    let mut i = 0;
     let n = v.length();
     while (i < n) {
         let cur = v[i];
@@ -97,7 +97,7 @@ and
 ```move
 use std::vector;
 fun check_vec(v: &vector<u64>, bound: u64) {
-    let i = 0;
+    let mut i = 0;
     let n = v.length();
     while (i < n) {
         let cur = v[i];
@@ -117,7 +117,7 @@ assert!(true, 1 / 0)
 Will not result in an arithmetic error, it is equivalent to
 
 ```move
-if (true) () else (1 / 0)
+if (true) () else abort (1 / 0)
 ```
 
 So the arithmetic expression is never evaluated!

--- a/reference/control-flow/pattern-matching.md
+++ b/reference/control-flow/pattern-matching.md
@@ -142,10 +142,10 @@ right-hand side of the match arm. For example:
 ```move
 public struct Wrapper(u64)
 
-fun add_under_wrapper_unless_equal(wrapper: Wrapper, x: u64): u64 {
+fun add_under_wrapper_unless_equal(wrapper: Wrapper, x: u64): Wrapper {
     match (wrapper) {
         Wrapper(y) if (y == x) => Wrapper(y),
-        Wrapper(y) => y + x,
+        Wrapper(y) => Wrapper(y + x),
     }
 }
 add_under_wrapper_unless_equal(Wrapper(1), 2); // returns Wrapper(3)
@@ -312,12 +312,13 @@ of the match arm.
 Take the following:
 
 ```move
-fun f(x: MyEnum) {
+fun f(x: MyEnum): u64 {
     match (x) {
         MyEnum::Variant(1, true) => 1,
         MyEnum::OtherVariant(_, 3) => 2,
         MyEnum::Variant(..) => 3,
         MyEnum::OtherVariant(..) => 4,
+    }
 }
 f(MyEnum::Variant(1, true)); // returns 1
 f(MyEnum::Variant(2, true)); // returns 3
@@ -335,12 +336,13 @@ You can also nest patterns. So, if you wanted to match either 1, 2, or 10, inste
 1 in the previous `MyEnum::Variant`, you could do so with an or-pattern:
 
 ```move
-fun f(x: MyEnum) {
+fun f(x: MyEnum): u64 {
     match (x) {
         MyEnum::Variant(1 | 2 | 10, true) => 1,
         MyEnum::OtherVariant(_, 3) => 2,
         MyEnum::Variant(..) => 3,
         MyEnum::OtherVariant(..) => 4,
+    }
 }
 f(MyEnum::Variant(1, true)); // returns 1
 f(MyEnum::Variant(2, true)); // returns 1
@@ -361,7 +363,7 @@ addition, if you fully destruct that value, you have unpacked it, matching the s
 ```move
 public struct NonDrop(u64)
 
-fun drop_nondrop(x: NonDrop) {
+fun drop_nondrop(x: NonDrop): u64 {
     match (x) {
         NonDrop(1) => 1,
         _ => 2
@@ -369,7 +371,7 @@ fun drop_nondrop(x: NonDrop) {
     }
 }
 
-fun destructure_nondrop(x: NonDrop) {
+fun destructure_nondrop(x: NonDrop): u64 {
     match (x) {
         NonDrop(1) => 1,
         NonDrop(_) => 2
@@ -529,7 +531,7 @@ Note that the `mut` modifier can only be applied to variables, and not other typ
 ```move
 public struct MyStruct(u64)
 
-fun top_level_mut(x: MyStruct) {
+fun top_level_mut(x: MyStruct): u64 {
     match (x) {
         mut MyStruct(y) => 1,
         // ERROR: cannot use mut on a non-variable pattern
@@ -547,7 +549,7 @@ fun mut_on_immut(x: &MyStruct): u64 {
 
 fun mut_on_value(x: MyStruct): u64 {
     match (x) {
-        MyStruct(mut y) =>  {
+        MyStruct(mut y) => {
             *y = *y + 1;
             *y
         },
@@ -556,7 +558,7 @@ fun mut_on_value(x: MyStruct): u64 {
 
 fun mut_on_mut(x: &mut MyStruct): u64 {
     match (x) {
-        MyStruct(mut y) =>  {
+        MyStruct(mut y) => {
             *y = *y + 1;
             *y
         },
@@ -597,7 +599,7 @@ public struct MyStruct2 {
     w: u64,
 }
 
-fun wild_match(x: MyStruct) {
+fun wild_match(x: MyStruct): u64 {
     match (x) {
         MyStruct(.., 1) => 1,
         // OK! The `..` pattern can be used at the beginning of the constructor pattern
@@ -610,7 +612,7 @@ fun wild_match(x: MyStruct) {
     }
 }
 
-fun wild_match2(x: MyStruct2) {
+fun wild_match2(x: MyStruct2): u64 {
     match (x) {
         MyStruct2 { x: 1, .. } => 1,
         MyStruct2 { x: 1, w: 2 .. } => 2,

--- a/reference/functions.md
+++ b/reference/functions.md
@@ -92,7 +92,7 @@ module a::n {
 
 module b::other {
     fun calls_m_foo(): u64 {
-        b::m::foo() // ERROR!
+        a::m::foo() // ERROR!
 //      ^^^^^^^^^^^ 'foo' can only be called from a module in `a`
     }
 }
@@ -265,7 +265,7 @@ sequence
 
 ```move
 fun example(): u64 {
-    let x = 0;
+    let mut x = 0;
     x = x + 1;
     x // returns 'x'
 }
@@ -406,7 +406,7 @@ use std::vector;
 use std::option::{Self, Option};
 
 fun index_of<T>(v: &vector<T>, target: &T): Option<u64> {
-    let i = 0;
+    let mut i = 0;
     let n = vector::length(v);
     while (i < n) {
         if (vector::borrow(v, i) == target) return option::some(i);

--- a/reference/structs.md
+++ b/reference/structs.md
@@ -356,7 +356,7 @@ bar.0 = Foo { x: 62, y: true }; // bar = Bar(Foo { x: 62, y: true })
 The dot syntax for assignment also works via a reference to a struct:
 
 ```move
-let foo = Foo { x: 3, y: true };
+let mut foo = Foo { x: 3, y: true };
 let foo_ref = &mut foo;
 foo_ref.x = foo_ref.x + 1;
 ```
@@ -400,7 +400,7 @@ module a::n {
     }
 
     fun f2() {
-        let foo_wrapper = Wrapper { foo: m::new_foo() };
+        let foo_wrapper = Wrapper { foo: a::m::new_foo() };
         //                               ^ valid the function is public
     }
 }

--- a/reference/variables.md
+++ b/reference/variables.md
@@ -17,7 +17,7 @@ Move programs use `let` to bind variable names to values:
 
 ```move
 let x = 1;
-let y = x + x:
+let y = x + x;
 ```
 
 `let` can also be used without binding a value to the local.
@@ -42,13 +42,12 @@ provided.
 
 ```move
 let x;
-let cond = true;
-let i = 0;
+let mut i = 0;
 loop {
     let (res, cond) = foo(i);
     if (!cond) {
         x = res;
-        break;
+        break
     };
     i = i + 1;
 }
@@ -263,10 +262,13 @@ fun new_x(): X {
 
 fun example() {
     let Y { x1: X(f), x2 } = Y { x1: new_x(), x2: new_x() };
-    assert!(f + x2.f == 2, 42);
+    assert!(f + x2.0 == 2, 42);
 
     let Y { x1: X(f1), x2: X(f2) } = Y { x1: new_x(), x2: new_x() };
     assert!(f1 + f2 == 2, 42);
+
+    // `struct X` without `drop` ability and needs to be destroyed manually
+    let X(_) = x2;
 }
 ```
 
@@ -355,12 +357,15 @@ fun example() {
     let mut y = Y { x1: new_x(), x2: new_x() };
 
     let Y { x1: X(f), x2 } = &y;
-    assert!(*f + x2.f == 2, 42);
+    assert!(*f + x2.0 == 2, 42);
 
     let Y { x1: X(f1), x2: X(f2) } = &mut y;
     *f1 = *f1 + 1;
     *f2 = *f2 + 1;
     assert!(*f1 + *f2 == 4, 42);
+
+    // `struct X and struct Y` without `drop` ability and needs to be destroyed manually
+    let Y { x1: X(_), x2: X(_) } = y;
 }
 ```
 

--- a/reference/variables.md
+++ b/reference/variables.md
@@ -736,7 +736,7 @@ Remember, locals can change type when they are shadowed.
 let x = 0;
 {
     let x = b"hello";
-    assert!(x = b"hello", 42);
+    assert!(x == b"hello", 42);
 };
 assert!(x == 0, 42);
 ```
@@ -812,7 +812,7 @@ let coins = vector[Coin { value: 0 }, Coin { value: 0 }];
 let s2 = s; // copy
 let foo2 = foo; // copy
 let coin2 = coin; // move
-let coins2 = coin; // move
+let coins2 = coins; // move
 
 let x = 0;
 let b = false;


### PR DESCRIPTION
## abort-and-assert.md

1. Cannot execute `i = i + 1` without `mut`
2. `if (true) () else (1 / 0)` is wrong because the two branches return different types. According to the context of the article, this should demonstrate `if (condition) () else abort code`, so this should be changed to `if (true) () else abort (1 / 0)`
Maybe `(1 / 0)` is intended to trigger `arithmetic_error`, but `if (true) () else (1 / 0)` still does not compile.

## functions.md

1. **line 95**: `a::m::foo()` instead of `b::m::foo()`
2. **line 268 && line 409**: add `mut`

## variables.md

1. **line 20:** `;` instead of `:`
2. **line 45 - 50:** The `cond` outside the loop is redundant in this example and `i` needs to be changed to `mut i`
3. **Remaining modifications:** `public struct X(u64)` needs to use `.0` to use its attributes. For `struct` without `drop` capability, it needs to be destroyed manually.

## pattern-matching.md

Function return value type is missing or does not match