### PR TITLE
[book] Code errors and readability optimization

### DIFF
--- a/book/storage/transfer-restrictions.md
+++ b/book/storage/transfer-restrictions.md
@@ -54,22 +54,22 @@ use book::transfer_a::{ObjectK, ObjectKS};
 
 // Fails! ObjectK is not `store`, and ObjectK is not internal to this module
 public fun transfer_k(k: ObjectK, to: address) {
-    sui::transfer::transfer(k, to);
+    transfer::transfer(k, to);
 }
 
 // Fails! ObjectKS has `store` but the function is not public
 public fun transfer_ks(ks: ObjectKS, to: address) {
-    sui::transfer::transfer(ks, to);
+    transfer::transfer(ks, to);
 }
 
 // Fails! ObjectK is not `store`, `public_transfer` requires `store`
-public fun public_transfer_k(k: ObjectK) {
-    sui::transfer::public_transfer(k);
+public fun public_transfer_k(k: ObjectK, to: address) {
+    transfer::public_transfer(k, to);
 }
 
 // Works! ObjectKS has `store` and the function is public
-public fun public_transfer_ks(y: ObjectKS, to: address) {
-    sui::transfer::public_transfer(y, to);
+public fun public_transfer_ks(ks: ObjectKS, to: address) {
+    transfer::public_transfer(ks, to);
 }
 ```
 


### PR DESCRIPTION
1. The `transfer` module can be used directly
2. **line 66:** Missing parameter
3. **line 71:** Use `ks` to name `ObjectKS` uniformly to improve readability