### PR TITLE
[reference] Remove duplicate code snippets

### DIFF
--- a/reference/control-flow/loops.md
+++ b/reference/control-flow/loops.md
@@ -126,22 +126,6 @@ fun foo() {
 }
 ```
 
-Here is an example that uses `loop` to write the `sum` function:
-
-```move
-fun sum(n: u64): u64 {
-    let sum = 0;
-    let i = 0;
-    loop {
-        i = i + 1;
-        if (i > n) break;
-        sum = sum + i
-    };
-
-    sum
-}
-```
-
 ### Using `break` with Values in `loop`
 
 Unlike `while` loops, which always return `()`, a `loop` may return a value using `break`. In doing


### PR DESCRIPTION
This example is at the beginning of `## loop Expressions` and does not need to be repeated exactly.