### PR TITLE
format code, assert and macro

### DIFF
--- a/book/move-basics/testing.md
+++ b/book/move-basics/testing.md
@@ -14,19 +14,22 @@ the bytecode and are never published.
 ```move
 module book::testing;
 
+#[test_only]
+use std::unit_test::assert_eq;
+
 // The test attribute is placed before the `fun` keyword (can be both above or
 // right before the `fun` keyword, as in `#[test] fun my_test() { ... }`)
 // The name of the test in this case would be `book::testing::simple_test`.
 #[test]
 fun simple_test() {
     let sum = 2 + 2;
-    assert!(sum == 4);
+    assert_eq!(sum, 4);
 }
 
 // The name of this test would be `book::testing::more_advanced_test`.
 #[test] fun more_advanced_test() {
     let sum = 2 + 2 + 2;
-    assert!(sum == 4);
+    assert_eq!(sum, 4);
 }
 ```
 
@@ -94,6 +97,9 @@ where the `#[test_only]` attribute comes in handy.
 ```move
 module book::testing;
 
+#[test_only]
+use std::unit_test::assert_eq;
+
 // Public function which uses the `secret` function.
 public fun multiply_by_secret(x: u64): u64 {
     x * secret()
@@ -114,7 +120,7 @@ public fun secret_for_testing(): u64 {
 // In the test environment we have access to the `secret_for_testing` function.
 fun test_multiply_by_secret() {
     let expected = secret_for_testing() * 2;
-    assert!(multiply_by_secret(2) == expected);
+    assert_eq!(multiply_by_secret(2), expected);
 }
 ```
 

--- a/book/programmability/witness-pattern.md
+++ b/book/programmability/witness-pattern.md
@@ -96,7 +96,7 @@ public struct Balance<phantom T> has store {
 
 /// Increase supply by `value` and create a new `Balance<T>` with this value.
 public fun increase_supply<T>(self: &mut Supply<T>, value: u64): Balance<T> {
-    assert!(value < (18446744073709551615u64 - self.value), EOverflow);
+    assert!(value < (std::u64::max_value!() - self.value), EOverflow);
     self.value = self.value + value;
     Balance { value }
 }

--- a/book/your-first-move/hello-world.md
+++ b/book/your-first-move/hello-world.md
@@ -148,18 +148,7 @@ excludes comments and some identifiers (for example, for constants).
 To demonstrate these features, let's replace the contents of the _sources/hello_world.move_ file
 with the following:
 
-```move
-/// The module `hello_world` under named address `hello_world`.
-/// The named address is set in the `Move.toml`.
-module hello_world::hello_world;
-
-// Imports the `String` type from the Standard Library
-use std::string::String;
-
-/// Returns the "Hello, World!" as a `String`.
-public fun hello_world(): String {
-    b"Hello, World!".to_string()
-}
+```move file=packages/hello_world/sources/hello_world.move anchor=source
 ```
 
 During compilation, the code is built, but not run. A compiled package only includes functions that
@@ -201,16 +190,7 @@ the compiler. We explain tests in depth in the [Testing](./../move-basics/testin
 
 Replace the contents of the `tests/hello_world_tests.move` with the following content:
 
-```move
-#[test_only]
-module hello_world::hello_world_tests;
-
-use hello_world::hello_world;
-
-#[test]
-fun test_hello_world() {
-    assert!(hello_world::hello_world() == b"Hello, World!".to_string(), 0);
-}
+```move file=packages/hello_world/tests/hello_world_tests.move anchor=test
 ```
 
 Here we import the `hello_world` module, and call its `hello_world` function to test that the output

--- a/packages/hello_world/sources/hello_world.move
+++ b/packages/hello_world/sources/hello_world.move
@@ -1,3 +1,4 @@
+// ANCHOR: source
 /// The module `hello_world` under named address `hello_world`.
 /// The named address is set in the `Move.toml`.
 module hello_world::hello_world;
@@ -9,3 +10,4 @@ use std::string::String;
 public fun hello_world(): String {
     b"Hello, World!".to_string()
 }
+// ANCHOR_END: source

--- a/packages/hello_world/tests/hello_world_tests.move
+++ b/packages/hello_world/tests/hello_world_tests.move
@@ -1,9 +1,13 @@
+// ANCHOR: test
 #[test_only]
 module hello_world::hello_world_tests;
+
+use std::unit_test::assert_eq;
 
 use hello_world::hello_world;
 
 #[test]
 fun test_hello_world() {
-    assert!(hello_world::hello_world() == b"Hello, World!".to_string(), 0);
+    assert_eq!(hello_world::hello_world(), b"Hello, World!".to_string());
 }
+// ANCHOR_END: test

--- a/packages/samples/examples/buffer.move
+++ b/packages/samples/examples/buffer.move
@@ -1,51 +1,46 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-module book::buffer {
-    /// Error returned when the buffer is overflowed.
-    const EBufferOverflow: u64 = 0;
+module book::buffer;
 
-    /// The Buffer struct represents a growable buffer.
-    public struct Buffer {
-        data: vector<u8>,
-        expected_len: Option<u64>
-    }
+/// Error returned when the buffer is overflowed.
+const EBufferOverflow: u64 = 0;
 
-    /// Creates a new empty buffer.
-    public fun new(): Buffer {
-        Buffer { data: vector[], expected_len: option::none() }
-    }
+/// The Buffer struct represents a growable buffer.
+public struct Buffer {
+    data: vector<u8>,
+    expected_len: Option<u64>
+}
 
-    /// Creates a new empty buffer with the specified capacity (in bytes).
-    /// If the buffer is overflowed, tx aborts with `EBufferOverflow`.
-    public fun alloc(len: u64): Buffer {
-        Buffer { data: vector[], expected_len: option::some(len) }
-    }
+/// Creates a new empty buffer.
+public fun new(): Buffer {
+    Buffer { data: vector[], expected_len: option::none() }
+}
 
-    /// Pushes the given data to the end of the buffer.
-    public fun push(self: &mut Buffer, data: vector<u8>) {
-        if (option::is_some(&self.expected_len)) {
-            let max_len = *option::borrow(&self.expected_len);
-            let future_len = self.len() + vector::length(&data);
-            assert!(future_len <= max_len, EBufferOverflow);
-        };
+/// Creates a new empty buffer with the specified capacity (in bytes).
+/// If the buffer is overflowed, tx aborts with `EBufferOverflow`.
+public fun alloc(len: u64): Buffer {
+    Buffer { data: vector[], expected_len: option::some(len) }
+}
 
-        vector::append(&mut self.data, data)
-    }
+/// Pushes the given data to the end of the buffer.
+public fun push(self: &mut Buffer, data: vector<u8>) {
+    self.expected_len.do_ref!(|max_len| assert!(self.len() + data.length() <= *max_len, EBufferOverflow));
+    self.data.append(data)
+}
 
-    /// Unwraps the buffer and returns the underlying vector.
-    public fun unwrap(self: Buffer): vector<u8> {
-        let Buffer { data, expected_len: _ } = self;
-        data
-    }
+/// Unwraps the buffer and returns the underlying vector.
+public fun unwrap(self: Buffer): vector<u8> {
+    let Buffer { data, expected_len: _ } = self;
+    data
+}
 
-    /// Returns the length of the buffer.
-    public fun len(self: &Buffer): u64 {
-        vector::length(&self.data)
-    }
+/// Returns the length of the buffer.
+public fun len(self: &Buffer): u64 {
+    self.data.length()
+}
 
-    /// Returns `true` if the buffer is empty.
-    public fun is_empty(self: &Buffer): bool {
-        vector::is_empty(&self.data)
-    }
+/// Returns `true` if the buffer is empty.
+public fun is_empty(self: &Buffer): bool {
+    self.data.is_empty()
 }

--- a/packages/samples/examples/ticket.move
+++ b/packages/samples/examples/ticket.move
@@ -1,44 +1,44 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-module book::ticket {
-    /// A Ticket for an event or a service. Non-transferable by default and
-    /// the usage varies based on the application.
-    public struct Ticket<T: store + drop> has key {
-        id: UID,
-        used: bool,
-        metadata: T
-    }
+module book::ticket;
 
-    /// Create a new Ticket with the metadata and the context.
-    /// No need for a Witness here!
-    public fun new<T: store + drop>(metadata: T, ctx: &mut TxContext): Ticket<T> {
-        Ticket {
-            id: object::new(ctx),
-            used: false,
-            metadata
-        }
-    }
+/// A Ticket for an event or a service. Non-transferable by default and
+/// the usage varies based on the application.
+public struct Ticket<T: store + drop> has key {
+    id: UID,
+    used: bool,
+    metadata: T
+}
 
-    /// Consume the Ticket. Requires a Witness of the metadata type.
-    /// May or may not be implemented by the application.
-    public fun consume<T: store + drop>(_meta: T, ticket: &mut Ticket<T>) {
-        ticket.used = true;
+/// Create a new Ticket with the metadata and the context.
+/// No need for a Witness here!
+public fun new<T: store + drop>(metadata: T, ctx: &mut TxContext): Ticket<T> {
+    Ticket {
+        id: object::new(ctx),
+        used: false,
+        metadata
     }
+}
 
-    /// Transfer the Ticket to another user. Requires a Witness of the metadata type.
-    /// May or may not be implemented by the application.
-    public fun transfer<T: store + drop>(_meta: T, ticket: Ticket<T>, to: address) {
-        transfer::transfer(ticket, to)
-    }
+/// Consume the Ticket. Requires a Witness of the metadata type.
+/// May or may not be implemented by the application.
+public fun consume<T: store + drop>(_meta: T, ticket: &mut Ticket<T>) {
+    ticket.used = true;
+}
 
-    /// Get the metadata of the Ticket.
-    public fun metadata<T: store + drop>(ticket: &Ticket<T>): &T {
-        &ticket.metadata
-    }
+/// Transfer the Ticket to another user. Requires a Witness of the metadata type.
+/// May or may not be implemented by the application.
+public fun transfer<T: store + drop>(_meta: T, ticket: Ticket<T>, to: address) {
+    transfer::transfer(ticket, to)
+}
 
-    /// Check if the Ticket has been used.
-    public fun is_used<T: store + drop>(ticket: &Ticket<T>): bool {
-        ticket.used
-    }
+/// Get the metadata of the Ticket.
+public fun metadata<T: store + drop>(ticket: &Ticket<T>): &T {
+    &ticket.metadata
+}
+
+/// Check if the Ticket has been used.
+public fun is_used<T: store + drop>(ticket: &Ticket<T>): bool {
+    ticket.used
 }

--- a/packages/samples/sources/move-basics/constants-shop-price.move
+++ b/packages/samples/sources/move-basics/constants-shop-price.move
@@ -6,6 +6,9 @@ module book::shop_price;
 
 use sui::{coin::Coin, sui::SUI};
 
+/// Trying to purchase an item at an incorrect price.
+const EWrongPrice: u64 = 0;
+
 /// The price of an item in the shop.
 const ITEM_PRICE: u64 = 100;
 /// The owner of the shop, an address.
@@ -16,7 +19,7 @@ public struct Item {}
 
 /// Purchase an item from the shop.
 public fun purchase(coin: Coin<SUI>): Item {
-    assert!(coin.value() == ITEM_PRICE);
+    assert!(coin.value() == ITEM_PRICE, EWrongPrice);
 
     transfer::public_transfer(coin, SHOP_OWNER);
 

--- a/packages/samples/sources/move-basics/control-flow.move
+++ b/packages/samples/sources/move-basics/control-flow.move
@@ -1,9 +1,13 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+#[allow(unused_function)]
 // ANCHOR: module
 module book::control_flow;
 // ANCHOR_END: module
+
+#[test_only]
+use std::unit_test::assert_eq;
 
 // ANCHOR: if_condition
 #[test]
@@ -26,7 +30,7 @@ fun test_if_else() {
         0
     };
 
-    assert!(y == 1);
+    assert_eq!(y, 1);
 }
 // ANCHOR_END: if_else
 // ANCHOR: while_loop
@@ -50,9 +54,9 @@ fun while_loop(mut x: u8): u8 {
 
 #[test]
 fun test_while() {
-    assert!(while_loop(0) == 10); // 10 times
-    assert!(while_loop(5) == 5);  // 5 times
-    assert!(while_loop(10) == 0); // loop never executed
+    assert_eq!(while_loop(0), 10); // 10 times
+    assert_eq!(while_loop(5), 5); // 5 times
+    assert_eq!(while_loop(10), 0); // loop never executed
 }
 // ANCHOR_END: while_loop
 // ANCHOR: infinite_while
@@ -66,7 +70,7 @@ fun test_infinite_while() {
     };
 
     // This line will never be executed.
-    assert!(x == 5);
+    assert_eq!(x, 5);
 }
 // ANCHOR_END: infinite_while
 #[allow(dead_code)]
@@ -81,7 +85,7 @@ fun test_infinite_loop() {
     };
 
     // This line will never be executed.
-    assert!(x == 5);
+    assert_eq!(x, 5);
 }
 // ANCHOR_END: infinite_loop
 // ANCHOR: break_loop
@@ -99,7 +103,7 @@ fun test_break_loop() {
         }
     };
 
-    assert!(x == 5);
+    assert_eq!(x, 5);
 }
 // ANCHOR_END: break_loop
 // ANCHOR: continue_loop
@@ -124,7 +128,7 @@ fun test_continue_loop() {
         }
     };
 
-    assert!(x == 10); // 10
+    assert_eq!(x, 10) // 10
 }
 // ANCHOR_END: continue_loop
 // ANCHOR: return_statement
@@ -144,8 +148,8 @@ fun is_positive(x: u8): bool {
 
 #[test]
 fun test_return() {
-    assert!(is_positive(5) == false);
-    assert!(is_positive(0) == false);
-    assert!(is_positive(1) == true);
+    assert_eq!(is_positive(5), false);
+    assert_eq!(is_positive(0), false);
+    assert_eq!(is_positive(1), true);
 }
 // ANCHOR_END: return_statement

--- a/packages/samples/sources/move-basics/function.move
+++ b/packages/samples/sources/move-basics/function.move
@@ -5,6 +5,9 @@
 // ANCHOR: math
 module book::math;
 
+#[test_only]
+use std::unit_test::assert_eq;
+
 /// Function takes two arguments of type `u64` and returns their sum.
 /// The `public` visibility modifier makes the function accessible from
 /// outside the module.
@@ -15,7 +18,7 @@ public fun add(a: u64, b: u64): u64 {
 #[test]
 fun test_add() {
     let sum = add(1, 2);
-    assert!(sum == 3);
+    assert_eq!(sum, 3);
 }
 // ANCHOR_END: math
 
@@ -36,8 +39,8 @@ fun get_name_and_age(): (vector<u8>, u8) {
 // Tuple must be destructured to access its elements.
 // Name and age are declared as immutable variables.
 let (name, age) = get_name_and_age();
-assert!(name == b"John");
-assert!(age == 25);
+assert_eq!(name, b"John");
+assert_eq!(age, 25);
 // ANCHOR_END: tuple_return_imm
 
 // ANCHOR: tuple_return_mut

--- a/packages/samples/sources/move-basics/generics.move
+++ b/packages/samples/sources/move-basics/generics.move
@@ -3,6 +3,9 @@
 #[allow(unused_variable, unused_field)]
 module book::generics;
 
+#[test_only]
+use std::unit_test::assert_eq;
+
 // ANCHOR: container
 /// Container for any type `T`.
 public struct Container<T> has drop {
@@ -23,7 +26,7 @@ fun test_container() {
     let container = new<u8>(10); // create a new `Container` with a `u8` value
     let container = new(10u8);
 
-    assert!(container.value == 10, 0x0);
+    assert_eq!(container.value, 10);
 
     // Value can be ignored only if it has the `drop` ability.
     let Container { value: _ } = container;
@@ -51,8 +54,8 @@ fun test_generic() {
     let pair_2 = new_pair<u8, bool>(10, true); // create a new `Pair` with a `u8` and `bool` values
     let pair_3 = new_pair(10u8, true);
 
-    assert!(pair_1.first == 10, 0x0);
-    assert!(pair_1.second, 0x0);
+    assert_eq!(pair_1.first, 10);
+    assert_eq!(pair_1.second, true);
 
     // Unpacking is identical.
     let Pair { first: _, second: _ } = pair_1;
@@ -69,13 +72,13 @@ fun test_swap_type_params() {
     let pair2: Pair<bool, u8> = new_pair(true, 10u8);
 
     // this line will not compile
-    // assert!(pair1 == pair2, 0x0);
+    // assert_eq!(pair1, pair2);
 
     let Pair { first: pf1, second: ps1 } = pair1; // first1: u8, second1: bool
     let Pair { first: pf2, second: ps2 } = pair2; // first2: bool, second2: u8
 
-    assert!(pf1 == ps2); // 10 == 10
-    assert!(ps1 == pf2); // true == true
+    assert_eq!(pf1, ps2); // 10 == 10
+    assert_eq!(ps1, pf2); // true == true
 }
 // ANCHOR_END: test_pair_swap
 

--- a/packages/samples/sources/move-basics/option.move
+++ b/packages/samples/sources/move-basics/option.move
@@ -24,6 +24,9 @@ public fun register(
 }
 // ANCHOR_END: registry
 
+#[test_only]
+use std::unit_test::{assert_eq, assert_ref_eq};
+
 #[test] fun use_option() {
 
 // ANCHOR: usage
@@ -35,16 +38,16 @@ let mut opt = option::some(b"Alice");
 let empty : Option<u64> = option::none();
 
 // `option.is_some()` returns true if option contains a value.
-assert!(opt.is_some());
-assert!(empty.is_none());
+assert_eq!(opt.is_some(), true);
+assert_eq!(empty.is_none(), true);
 
 // internal value can be `borrow`ed and `borrow_mut`ed.
-assert!(opt.borrow() == &b"Alice");
+assert_ref_eq!(opt.borrow(), &b"Alice");
 
 // `option.extract` takes the value out of the option, leaving the option empty.
 let inner = opt.extract();
 
 // `option.is_none()` returns true if option is None.
-assert!(opt.is_none());
+assert_eq!(opt.is_none(), true);
 // ANCHOR_END: usage
 }

--- a/packages/samples/sources/move-basics/struct-methods-2.move
+++ b/packages/samples/sources/move-basics/struct-methods-2.move
@@ -32,13 +32,16 @@ public use fun villain_health as Villain.health;
 
 public fun villain_health(villain: &Villain): u8 { villain.health }
 
+#[test_only]
+use std::unit_test::assert_eq;
+
 #[test]
 // Test the methods of the `Hero` and `Villain` structs.
 fun test_associated_methods() {
     let hero = new_hero();
-    assert!(hero.health() == 100);
+    assert_eq!(hero.health(), 100);
 
     let villain = new_villain();
-    assert!(villain.health() == 200);
+    assert_eq!(villain.health(), 200);
 }
 // ANCHOR_END: hero_and_villain

--- a/packages/samples/sources/move-basics/struct-methods-3.move
+++ b/packages/samples/sources/move-basics/struct-methods-3.move
@@ -18,11 +18,14 @@ public struct Hero has drop {
 /// Create a new Hero.
 public fun new(): Hero { Hero { health: 100, mana: 100 } }
 
+#[test_only]
+use std::unit_test::assert_eq;
+
 #[test]
 // Test the methods of the `Hero` struct.
 fun test_hero_serialize() {
     // let mut hero = new();
     // let serialized = hero.to_bytes();
-    // assert!(serialized.length() == 3, 1);
+    // assert_eq!(serialized.length(), 3);
 }
 // ANCHOR_END: hero_to_bytes

--- a/packages/samples/sources/move-basics/struct-methods.move
+++ b/packages/samples/sources/move-basics/struct-methods.move
@@ -25,13 +25,16 @@ public fun health(hero: &Hero): u8 { hero.health }
 /// A method which returns the mana of the hero.
 public fun mana(hero: &Hero): u8 { hero.mana }
 
+#[test_only]
+use std::unit_test::assert_eq;
+
 #[test]
 // Test the methods of the `Hero` struct.
 fun test_methods() {
     let mut hero = new();
     hero.heal_spell();
 
-    assert!(hero.health() == 110);
-    assert!(hero.mana() == 90);
+    assert_eq!(hero.health(), 110);
+    assert_eq!(hero.mana(), 90);
 }
 // ANCHOR_END: hero

--- a/packages/samples/sources/move-basics/struct.move
+++ b/packages/samples/sources/move-basics/struct.move
@@ -28,6 +28,9 @@ public struct Record {
 }
 // ANCHOR_END: def
 
+#[test_only]
+use std::unit_test::assert_eq;
+
 #[test] fun test_pack_unpack() {
 
 // ANCHOR: pack
@@ -41,13 +44,13 @@ let mut artist = Artist {
 let artist_name = artist.name;
 
 // Access a field of the `Artist` struct.
-assert!(artist.name == b"The Beatles".to_string());
+assert_eq!(artist.name, b"The Beatles".to_string());
 
 // Mutate the `name` field of the `Artist` struct.
 artist.name = b"Led Zeppelin".to_string();
 
 // Check that the `name` field has been mutated.
-assert!(artist.name == b"Led Zeppelin".to_string());
+assert_eq!(artist.name, b"Led Zeppelin".to_string());
 // ANCHOR_END: access
 
 // ANCHOR: unpack

--- a/packages/samples/sources/move-basics/type-reflection.move
+++ b/packages/samples/sources/move-basics/type-reflection.move
@@ -26,12 +26,13 @@ public fun do_i_know_you<T>(): (String, String, String) {
 
 #[test_only]
 public struct MyType {}
+#[test_only]
+use std::unit_test::assert_eq;
 
 #[test]
 fun test_type_reflection() {
     let (type_name, module_name, _address_str) = do_i_know_you<MyType>();
 
-    //
-    assert!(module_name == b"type_reflection".to_ascii_string());
+    assert_eq!(module_name, b"type_reflection".to_ascii_string());
 }
 // ANCHOR_END: main

--- a/packages/samples/sources/move-basics/vector.move
+++ b/packages/samples/sources/move-basics/vector.move
@@ -3,6 +3,8 @@
 
 #[allow(unused_variable)]
 module book::vector_syntax {
+#[test_only]
+use std::unit_test::assert_eq;
 #[test] fun test_vector() {
 // ANCHOR: literal
 // An empty vector of bool elements.
@@ -23,13 +25,13 @@ let vv: vector<vector<u8>> = vector[
 // ANCHOR: methods
 let mut v = vector[10u8, 20, 30];
 
-assert!(v.length() == 3);
-assert!(!v.is_empty());
+assert_eq!(v.length(), 3);
+assert_eq!(v.is_empty(), false);
 
 v.push_back(40);
 let last_value = v.pop_back();
 
-assert!(last_value == 40);
+assert_eq!(last_value, 40);
 // ANCHOR_END: methods
 }
 }

--- a/packages/samples/sources/programmability/bcs.move
+++ b/packages/samples/sources/programmability/bcs.move
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-#[allow(unused_variable)]
+#[allow(unused_variable, unused_field)]
 module book::bcs {
     use std::string::String;
 
@@ -16,6 +16,9 @@ public struct User has drop {
     is_active: bool,
     name: String
 }
+
+#[test_only]
+use std::unit_test::assert_eq;
 
 #[test] fun test_encode() {
 // ANCHOR: encode
@@ -47,7 +50,7 @@ custom_bytes.append(bcs::to_bytes(&b"hello, world!".to_string()));
 custom_bytes.append(bcs::to_bytes(&true));
 
 // struct is just a sequence of fields, so the bytes should be the same!
-assert!(&struct_bytes == &custom_bytes);
+assert_eq!(struct_bytes, custom_bytes);
 // ANCHOR_END: encode_struct
 }
 
@@ -61,12 +64,12 @@ let mut bcs = bcs::new(x"010000000000000000");
 // Same bytes can be read differently, for example: Option<u64>
 let value: Option<u64> = bcs.peel_option_u64();
 
-assert!(value.is_some());
-assert!(value.borrow() == &0);
+assert_eq!(value.is_some(), true);
+assert_eq!(*value.borrow(), 0);
 
 let remainder = bcs.into_remainder_bytes();
 
-assert!(remainder.length() == 0);
+assert_eq!(remainder.length(), 0);
 // ANCHOR_END: decode
 
 // ANCHOR: chain_decode
@@ -94,21 +97,25 @@ while (len > 0) {
     len = len - 1;
 };
 
-assert!(vec.length() == 1);
+assert_eq!(vec.length(), 1);
+
+// The above `while` can be simplified and made more readable using a `macro`.
+// After using the following macro function, will get the equivalent of `vec`.
+// let vec = vector::tabulate!(bcs.peel_vec_length(), |_| bcs.peel_u64());
 // ANCHOR_END: decode_vector
 
 // ANCHOR: decode_option
 let mut bcs = bcs::new(x"00");
 let is_some = bcs.peel_bool();
 
-assert!(is_some == false);
+assert_eq!(is_some, false);
 
 let mut bcs = bcs::new(x"0101");
 let is_some = bcs.peel_bool();
 let value = bcs.peel_u8();
 
-assert!(is_some == true);
-assert!(value == 1);
+assert_eq!(is_some, true);
+assert_eq!(value, 1);
 // ANCHOR_END: decode_option
 
 // ANCHOR: decode_struct

--- a/packages/samples/sources/programmability/collections-2.move
+++ b/packages/samples/sources/programmability/collections-2.move
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-#[allow(unused_variable, unused_field)]
+#[allow(unused_variable, unused_field, unused_use)]
 // ANCHOR: vec_set
 module book::collections_vec_set;
 
@@ -12,6 +12,9 @@ public struct App has drop {
     subscribers: VecSet<address>
 }
 
+#[test_only]
+use std::unit_test::assert_eq;
+
 #[test]
 fun vec_set_playground() {
     let set = vec_set::empty<u8>(); // create an empty set
@@ -20,9 +23,9 @@ fun vec_set_playground() {
     set.insert(2); // add an item to the set
     set.insert(3);
 
-    assert!(set.contains(&1)); // check if an item is in the set
-    assert!(set.size() == 3); // get the number of items in the set
-    assert!(!set.is_empty()); // check if the set is empty
+    assert_eq!(set.contains(&1), true); // check if an item is in the set
+    assert_eq!(set.size(), 3); // get the number of items in the set
+    assert_eq!(set.is_empty(), false); // check if the set is empty
 
     set.remove(&2); // remove an item from the set
 }

--- a/packages/samples/sources/programmability/collections-4.move
+++ b/packages/samples/sources/programmability/collections-4.move
@@ -1,10 +1,13 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-#[allow(unused_field, unused_variable, lint(collection_equality))]
+#[allow(unused_use, lint(collection_equality))]
 module book::collections_compare_vec_set;
 
 use sui::vec_set;
+
+#[test_only]
+use std::unit_test::assert_eq;
 
 #[test, expected_failure]
 fun test_compare() {
@@ -17,6 +20,6 @@ let mut set2 = vec_set::empty();
 set2.insert(2);
 set2.insert(1);
 
-assert!(set1 == set2); // aborts!
+assert_eq!(set1, set2); // aborts!
 // ANCHOR_END: vec_set_comparison
 }

--- a/packages/samples/sources/programmability/dynamic-collections.move
+++ b/packages/samples/sources/programmability/dynamic-collections.move
@@ -16,6 +16,9 @@ public struct Carrier has key {
 }
 // ANCHOR_END: bag_struct
 
+#[test_only]
+use std::unit_test::assert_eq;
+
 #[test] fun test_bag() {
 let ctx = &mut tx_context::dummy();
 
@@ -23,12 +26,12 @@ let ctx = &mut tx_context::dummy();
 let mut bag = bag::new(ctx);
 
 // bag has the `length` function to get the number of elements
-assert!(bag.length() == 0);
+assert_eq!(bag.length(), 0);
 
 bag.add(b"my_key", b"my_value".to_string());
 
 // length has changed to 1
-assert!(bag.length() == 1);
+assert_eq!(bag.length(), 1);
 
 // in order: `borrow`, `borrow_mut` and `remove`
 // the value type must be specified
@@ -64,13 +67,13 @@ let ctx = &mut tx_context::dummy();
 let mut table = table::new<address, String>(ctx);
 
 // table has the `length` function to get the number of elements
-assert!(table.length() == 0);
+assert_eq!(table.length(), 0);
 
 table.add(@0xa11ce, b"my_value".to_string());
 table.add(@0xb0b, b"another_value".to_string());
 
 // length has changed to 2
-assert!(table.length() == 2);
+assert_eq!(table.length(), 2);
 
 // in order: `borrow`, `borrow_mut` and `remove`
 let value_ref = &table[@0xa11ce];
@@ -108,14 +111,14 @@ let ctx = &mut tx_context::dummy();
 let mut linked_table = linked_table::new<address, String>(ctx);
 
 // linked_table has the `length` function to get the number of elements
-assert!(linked_table.length() == 0);
+assert_eq!(linked_table.length(), 0);
 
 linked_table.push_front(@0xa0a, b"first_value".to_string());
 linked_table.push_back(@0xb1b, b"second_value".to_string());
 linked_table.push_back(@0xc2c, b"third_value".to_string());
 
 // length has changed to 3
-assert!(linked_table.length() == 3);
+assert_eq!(linked_table.length(), 3);
 
 // in order: `borrow`, `borrow_mut` and `remove`
 let first_value_ref = &linked_table[@0xa0a];

--- a/packages/samples/sources/programmability/dynamic-fields.move
+++ b/packages/samples/sources/programmability/dynamic-fields.move
@@ -1,6 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+#[allow(unused_field)]
 // ANCHOR: usage
 module book::dynamic_fields;
 
@@ -39,8 +40,8 @@ fun test_character_and_accessories() {
     );
 
     // Check that the hat and mustache are attached to the character
-    assert!(df::exists_(&character.id, b"hat_key"), 0);
-    assert!(df::exists_(&character.id, b"mustache_key"), 1);
+    assert!(df::exists_(&character.id, b"hat_key"));
+    assert!(df::exists_(&character.id, b"mustache_key"));
 
     // Modify the color of the hat
     let hat: &mut Hat = df::borrow_mut(&mut character.id, b"hat_key");
@@ -51,8 +52,8 @@ fun test_character_and_accessories() {
     let mustache: Mustache = df::remove(&mut character.id, b"mustache_key");
 
     // Check that the hat and mustache are no longer attached to the character
-    assert!(!df::exists_(&character.id, b"hat_key"), 0);
-    assert!(!df::exists_(&character.id, b"mustache_key"), 1);
+    assert!(!df::exists_(&character.id, b"hat_key"));
+    assert!(!df::exists_(&character.id, b"mustache_key"));
 
     sui::test_utils::destroy(character);
     sui::test_utils::destroy(mustache);

--- a/packages/samples/sources/your-first-move/hello_world.move
+++ b/packages/samples/sources/your-first-move/hello_world.move
@@ -9,8 +9,11 @@ public fun hello_world(): String {
     b"Hello, World!".to_string()
 }
 
+#[test_only]
+use std::unit_test::assert_eq;
+
 #[test]
 fun test_is_hello_world() {
     let expected = b"Hello, World!".to_string();
-    assert!(hello_world() == expected)
+    assert_eq!(hello_world(), expected);
 }

--- a/packages/samples/sources/your-first-move/hello_world_debug.move
+++ b/packages/samples/sources/your-first-move/hello_world_debug.move
@@ -12,10 +12,13 @@ public fun hello_world(): String {
     result
 }
 
+#[test_only]
+use std::unit_test::assert_eq;
+
 #[test]
 fun test_is_hello_world() {
     let expected = b"Hello, World!".to_string();
     let actual = hello_world();
 
-    assert!(actual == expected)
+    assert_eq!(actual, expected);
 }

--- a/packages/samples/sources/your-first-move/hello_world_docs.move
+++ b/packages/samples/sources/your-first-move/hello_world_docs.move
@@ -11,11 +11,14 @@ public fun hello_world(): String {
     b"Hello, World!".to_string()
 }
 
+#[test_only]
+use std::unit_test::assert_eq;
+
 #[test]
 /// This is a test for the `hello_world` function.
 fun test_is_hello_world() {
     let expected = b"Hello, World!".to_string();
     let actual = hello_world();
 
-    assert!(actual == expected)
+    assert_eq!(actual, expected);
 }

--- a/reference/abort-and-assert.md
+++ b/reference/abort-and-assert.md
@@ -40,8 +40,6 @@ vector does not have two items
 <!-- {{#include ../../packages/reference/sources/abort-and-assert.move}} -->
 
 ```move
-use std::vector;
-
 fun pop_twice<T>(v: &mut vector<T>): (T, T) {
     if (v.length() < 2) abort 42;
     (v.pop_back(), v.pop_back())
@@ -52,7 +50,6 @@ This is even more useful deep inside a control-flow construct. For example, this
 that all numbers in the vector are less than the specified `bound`. And aborts otherwise
 
 ```move
-use std::vector;
 fun check_vec(v: &vector<u64>, bound: u64) {
     let mut i = 0;
     let n = v.length();
@@ -61,6 +58,13 @@ fun check_vec(v: &vector<u64>, bound: u64) {
         if (cur > bound) abort 42;
         i = i + 1;
     }
+}
+```
+
+> Combine `macro` with `abort`:
+```move
+fun check_vec(v: &vector<u64>, bound: u64) {
+    v.do_ref!(|num| if (*num > bound) abort 42);
 }
 ```
 
@@ -85,7 +89,6 @@ if (condition) () else abort code
 rewritten using `assert`
 
 ```move
-use std::vector;
 fun pop_twice<T>(v: &mut vector<T>): (T, T) {
     assert!(v.length() >= 2, 42); // Now uses 'assert'
     (v.pop_back(), v.pop_back())
@@ -95,7 +98,6 @@ fun pop_twice<T>(v: &mut vector<T>): (T, T) {
 and
 
 ```move
-use std::vector;
 fun check_vec(v: &vector<u64>, bound: u64) {
     let mut i = 0;
     let n = v.length();
@@ -104,6 +106,13 @@ fun check_vec(v: &vector<u64>, bound: u64) {
         assert!(cur <= bound, 42); // Now uses 'assert'
         i = i + 1;
     }
+}
+```
+
+> Combine `macro` with `assert`:
+```move
+fun check_vec(v: &vector<u64>, bound: u64) {
+    v.do_ref!(|num| assert!(*num <= bound, 42));
 }
 ```
 

--- a/reference/control-flow/labeled-control-flow.md
+++ b/reference/control-flow/labeled-control-flow.md
@@ -75,6 +75,18 @@ let x = 'outer: loop {
 };
 ```
 
+> It's a better way to use Macros instead of Loops, similarly, use `return` to control the flow.
+> Just like above function `sum_until_threshold`, can use `macro` to rewrite it:
+```move
+fun sum_until_threshold(input: &vector<vector<u64>>, threshold: u64): u64 {
+    'outer: {
+        (*input).fold!(0, |sum, inner_vec| {
+            inner_vec.fold!(sum, |sum, num| if (sum + num < threshold) sum + num else return 'outer sum)
+        })
+    }
+}
+```
+
 ## Labeled Blocks
 
 Labeled blocks allow you to write Move programs that contain intra-function non-local control flow,

--- a/reference/control-flow/loops.md
+++ b/reference/control-flow/loops.md
@@ -38,6 +38,14 @@ fun foo() {
 }
 ```
 
+> It's a better way to use Macros instead of Loops to achieve a more concise and readable purpose.
+> This article only takes the above function `sum` as an example to experience the charm of macro functions:
+```move
+fun sum(n: u64): u64 {
+    vector::tabulate!(n, |i| i + 1).fold!(0, |sum, num| sum + num)
+}
+```
+
 ### Using `break` Inside of `while` Loops
 
 In Move, `while` loops can use `break` to exit early. For example, suppose we were looking for the
@@ -45,12 +53,12 @@ position of a value in a vector, and would like to `break` if we find it:
 
 ```move
 fun find_position(values: &vector<u64>, target_value: u64): Option<u64> {
-    let size = vector::length(values);
+    let size = values.length();
     let mut i = 0;
     let mut found = false;
 
     while (i < size) {
-        if (vector::borrow(values, i) == &target_value) {
+        if (values[i] == target_value) {
             found = true;
             break
         };
@@ -79,12 +87,12 @@ example:
 
 ```move
 fun sum_even(values: &vector<u64>): u64 {
-    let size = vector::length(values);
+    let size = values.length();
     let mut i = 0;
     let mut even_sum = 0;
 
     while (i < size) {
-        let number = *vector::borrow(values, i);
+        let number = values[i];
         i = i + 1;
         if (number % 2 == 1) continue;
         even_sum = even_sum + number;
@@ -134,11 +142,11 @@ so, the overall `loop` expression evaluates to a value of that type. For example
 
 ```move
 fun find_position(values: &vector<u64>, target_value: u64): Option<u64> {
-    let size = vector::length(values);
+    let size = values.length();
     let mut i = 0;
 
     loop {
-        if (vector::borrow(values, i) == &target_value) {
+        if (values[i] == target_value) {
             break option::some(i)
         } else if (i >= size) {
             break option::none()
@@ -158,13 +166,13 @@ function rewritten using `loop` with `break `and` continue` instead of `while`.
 
 ```move
 fun sum_even(values: &vector<u64>): u64 {
-    let size = vector::length(values);
+    let size = values.length();
     let mut i = 0;
     let mut even_sum = 0;
 
     loop {
         if (i >= size) break;
-        let number = *vector::borrow(values, i);
+        let number = values[i];
         i = i + 1;
         if (number % 2 == 1) continue;
         even_sum = even_sum + number;

--- a/reference/functions.md
+++ b/reference/functions.md
@@ -402,14 +402,11 @@ However `return` really shines is in exiting deep within other control flow cons
 example, the function iterates through a vector to find the index of a given value:
 
 ```move
-use std::vector;
-use std::option::{Self, Option};
-
 fun index_of<T>(v: &vector<T>, target: &T): Option<u64> {
     let mut i = 0;
-    let n = vector::length(v);
+    let n = v.length();
     while (i < n) {
-        if (vector::borrow(v, i) == target) return option::some(i);
+        if (&v[i] == target) return option::some(i);
         i = i + 1
     };
 


### PR DESCRIPTION
- format code
- delete error codes when using `assert` in tests or use `assert_eq` instead of it directly
- add error codes when using `assert` in normal module
- use `macro` and add some equivalent examples in md