### PR TITLE
feat: complete external module method aliasing example

### DIFF
--- a/book/move-basics/struct-methods.md
+++ b/book/move-basics/struct-methods.md
@@ -57,7 +57,7 @@ structs.
 > `public use fun hero_health as Hero.health`, which provides controlled access to the private
 > field.
 
-<!-- ## Aliasing an external module's method
+## Aliasing an external module's method
 
 It is also possible to associate a function defined in another module with a struct from the current
 module. Following the same approach, we can create an alias for the method defined in another
@@ -66,7 +66,7 @@ associate it with the `Hero` struct. It will allow serializing the `Hero` struct
 bytes.
 
 ```move file=packages/samples/sources/move-basics/struct-methods-3.move anchor=hero_to_bytes
-``` -->
+```
 
 ## Further Reading
 

--- a/packages/samples/sources/move-basics/struct-methods-3.move
+++ b/packages/samples/sources/move-basics/struct-methods-3.move
@@ -2,12 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // ANCHOR: hero_to_bytes
-// TODO: better example (external module...)
 module book::hero_to_bytes;
 
-// Alias for the `bcs::to_bytes` method. Imported aliases should be defined
-// in the top of the module.
-// public use fun bcs::to_bytes as Hero.to_bytes;
+use sui::bcs;
+
+// Alias for the `bcs::to_bytes` method. This allows us to use the method
+// on the Hero struct as if it were a native method.
+public use fun bcs::to_bytes as Hero.to_bytes;
 
 /// A struct representing a hero.
 public struct Hero has drop {
@@ -19,10 +20,13 @@ public struct Hero has drop {
 public fun new(): Hero { Hero { health: 100, mana: 100 } }
 
 #[test]
-// Test the methods of the `Hero` struct.
+// Test the `to_bytes` method on the Hero struct.
 fun test_hero_serialize() {
-    // let mut hero = new();
-    // let serialized = hero.to_bytes();
-    // assert!(serialized.length() == 3, 1);
+    let hero = new();
+    // Call the `to_bytes` method as if it's a method of Hero
+    let serialized = hero.to_bytes();
+    
+    // Verify the serialization worked
+    assert!(serialized.length() > 0, 1);
 }
 // ANCHOR_END: hero_to_bytes


### PR DESCRIPTION
## Problem Description
The `struct-methods-3.move` file contained a TODO comment and incomplete example for demonstrating external module method aliasing. The corresponding documentation section was commented out.

## Changes Made
- Removed TODO comment and implemented a complete working example
- Added proper BCS module import and method aliasing syntax  
- Implemented a functional test with assertions
- Uncommented the corresponding documentation section in `struct-methods.md`
- The example now clearly demonstrates how to alias external module methods as struct methods

## Technical Details
The example shows how to use `public use fun bcs::to_bytes as Hero.to_bytes` to create a method alias that allows calling `hero.to_bytes()` directly on Hero instances, making the external BCS serialization method feel like a native struct method.

## Testing
- [x] The code compiles successfully
- [x] The test demonstrates the feature correctly
- [x] Documentation and code example are now in sync

## Impact
- Completes a previously incomplete section of the book
- Provides readers with a practical example of method aliasing from external modules
- Improves the overall quality and completeness of the documentation