### PR TITLE
docs: add sitemap for afdocs llms-txt-coverage test

### DIFF
--- a/site/docusaurus.config.ts
+++ b/site/docusaurus.config.ts
@@ -35,6 +35,7 @@ export default {
 
   plugins: [
     llmsTxt,
+    '@docusaurus/plugin-sitemap',
     [
       '@docusaurus/plugin-content-docs',
       {


### PR DESCRIPTION
The afdocs spec requires a sitemap.xml to assess llms.txt coverage. Add @docusaurus/plugin-sitemap (already installed via preset-classic).