### PR TITLE
feat(docs): add Kapa.ai sidebar integration

### DIFF
--- a/site/docusaurus.config.ts
+++ b/site/docusaurus.config.ts
@@ -154,25 +154,6 @@ export default {
     require.resolve('./src/clientModules/kapa-sidebar.js'),
   ],
 
-  scripts: [
-    {
-      src: 'https://widget.kapa.ai/kapa-widget.bundle.js',
-      'data-website-id': 'de266438-2cd4-4ed5-9633-a1c6b931dd7d',
-      'data-project-name': 'Move Book',
-      'data-project-color': '#298DFF',
-      'data-button-hide': 'true',
-      'data-view-mode': 'sidebar',
-      'data-modal-title': 'Ask Move AI',
-      'data-modal-ask-ai-input-placeholder': 'Ask me anything about Move!',
-      'data-modal-example-questions':
-        'How do I define a struct in Move?,What are abilities in Move?,How do I publish a Move package?,What are dynamic fields?',
-      'data-modal-overlay-hidden': 'true',
-      'data-modal-lock-scroll': 'false',
-      'data-modal-image': '/favicon.svg',
-      async: true,
-    },
-  ],
-
   stylesheets: [
     {
       href: 'https://fonts.googleapis.com/css2?family=Rubik:wght@300&amp;display=swap',

--- a/site/docusaurus.config.ts
+++ b/site/docusaurus.config.ts
@@ -149,7 +149,29 @@ export default {
     ],
   ],
 
-  clientModules: [require.resolve('./src/clientModules/plausiblePageview.js')],
+  clientModules: [
+    require.resolve('./src/clientModules/plausiblePageview.js'),
+    require.resolve('./src/clientModules/kapa-sidebar.js'),
+  ],
+
+  scripts: [
+    {
+      src: 'https://widget.kapa.ai/kapa-widget.bundle.js',
+      'data-website-id': '6c642476-22cd-4976-888e-9949ea770589',
+      'data-project-name': 'Move Book',
+      'data-project-color': '#298DFF',
+      'data-button-hide': 'true',
+      'data-view-mode': 'sidebar',
+      'data-modal-title': 'Ask Move AI',
+      'data-modal-ask-ai-input-placeholder': 'Ask me anything about Move!',
+      'data-modal-example-questions':
+        'How do I define a struct in Move?,What are abilities in Move?,How do I publish a Move package?,What are dynamic fields?',
+      'data-modal-overlay-hidden': 'true',
+      'data-modal-lock-scroll': 'false',
+      'data-modal-image': '/favicon.svg',
+      async: true,
+    },
+  ],
 
   stylesheets: [
     {

--- a/site/docusaurus.config.ts
+++ b/site/docusaurus.config.ts
@@ -157,7 +157,7 @@ export default {
   scripts: [
     {
       src: 'https://widget.kapa.ai/kapa-widget.bundle.js',
-      'data-website-id': '6c642476-22cd-4976-888e-9949ea770589',
+      'data-website-id': 'de266438-2cd4-4ed5-9633-a1c6b931dd7d',
       'data-project-name': 'Move Book',
       'data-project-color': '#298DFF',
       'data-button-hide': 'true',

--- a/site/src/clientModules/kapa-sidebar.js
+++ b/site/src/clientModules/kapa-sidebar.js
@@ -1,0 +1,82 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Detects Kapa sidebar open/close and toggles .kapa-sidebar-open on <html>.
+// Kapa renders in Shadow DOM so we can't query its internals.
+// Strategy: hook Kapa.open for instant open detection, then use
+// elementFromPoint to detect close (checks if right edge of screen
+// is covered by a non-docusaurus element).
+
+if (typeof window !== "undefined") {
+  const OPEN_CLASS = "kapa-sidebar-open";
+  let kapaOpen = false;
+  let hookedRef = null;
+
+  function syncClass() {
+    document.documentElement.classList.toggle(OPEN_CLASS, kapaOpen);
+  }
+
+  function hookKapa() {
+    if (!window.Kapa || !window.Kapa.open || window.Kapa.open === hookedRef) return;
+
+    const origOpen = window.Kapa.open;
+    const origClose = window.Kapa.close;
+
+    window.Kapa.open = function (...args) {
+      kapaOpen = true;
+      syncClass();
+      return origOpen.apply(this, args);
+    };
+
+    window.Kapa.close = function (...args) {
+      kapaOpen = false;
+      syncClass();
+      return origClose.apply(this, args);
+    };
+
+    hookedRef = window.Kapa.open;
+  }
+
+  // Check if Kapa sidebar is covering the right side of the viewport
+  function isSidebarVisible() {
+    const x = window.innerWidth - 50;
+    const y = window.innerHeight / 2;
+    const el = document.elementFromPoint(x, y);
+    if (!el) return false;
+    // If the element at the right edge is inside #__docusaurus, sidebar is closed
+    const docRoot = document.getElementById("__docusaurus");
+    if (docRoot && docRoot.contains(el)) return false;
+    // If it's the body or html itself, sidebar is closed
+    if (el === document.body || el === document.documentElement) return false;
+    // Otherwise something (Kapa) is covering that spot
+    return true;
+  }
+
+  // Navigation hooks for SPA
+  const origPush = history.pushState.bind(history);
+  const origReplace = history.replaceState.bind(history);
+  history.pushState = function (...args) {
+    const r = origPush(...args);
+    syncClass();
+    return r;
+  };
+  history.replaceState = function (...args) {
+    const r = origReplace(...args);
+    syncClass();
+    return r;
+  };
+  window.addEventListener("popstate", syncClass);
+
+  // Poll every 300ms
+  setInterval(() => {
+    hookKapa();
+
+    const visible = isSidebarVisible();
+    if (visible && !kapaOpen) {
+      kapaOpen = true;
+    } else if (!visible && kapaOpen) {
+      kapaOpen = false;
+    }
+    syncClass();
+  }, 300);
+}

--- a/site/src/clientModules/kapa-sidebar.js
+++ b/site/src/clientModules/kapa-sidebar.js
@@ -21,7 +21,6 @@ if (typeof window !== "undefined") {
     "data-modal-example-questions": "How do I define a struct in Move?,What are abilities in Move?,How do I publish a Move package?,What are dynamic fields?",
     "data-modal-overlay-hidden": "true",
     "data-modal-lock-scroll": "false",
-    "data-modal-image": "/favicon.svg",
     "data-color-scheme-selector": "[data-theme='dark']",
   };
   for (const [key, value] of Object.entries(attrs)) {

--- a/site/src/clientModules/kapa-sidebar.js
+++ b/site/src/clientModules/kapa-sidebar.js
@@ -21,6 +21,7 @@ if (typeof window !== "undefined") {
     "data-modal-example-questions": "How do I define a struct in Move?,What are abilities in Move?,How do I publish a Move package?,What are dynamic fields?",
     "data-modal-overlay-hidden": "true",
     "data-modal-lock-scroll": "false",
+    "data-modal-logo-hidden": "true",
     "data-color-scheme-selector": "[data-theme='dark']",
   };
   for (const [key, value] of Object.entries(attrs)) {

--- a/site/src/clientModules/kapa-sidebar.js
+++ b/site/src/clientModules/kapa-sidebar.js
@@ -1,13 +1,35 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-// Detects Kapa sidebar open/close and toggles .kapa-sidebar-open on <html>.
-// Kapa renders in Shadow DOM so we can't query its internals.
-// Strategy: hook Kapa.open for instant open detection, then use
-// elementFromPoint to detect close (checks if right edge of screen
-// is covered by a non-docusaurus element).
+// Injects the Kapa widget script with all configuration (including
+// data-color-scheme-selector which Docusaurus strips due to nested quotes),
+// then detects sidebar open/close and toggles .kapa-sidebar-open on <html>.
 
 if (typeof window !== "undefined") {
+  // Inject the Kapa widget script tag with all attributes
+  const script = document.createElement("script");
+  script.src = "https://widget.kapa.ai/kapa-widget.bundle.js";
+  script.async = true;
+  const attrs = {
+    "data-website-id": "de266438-2cd4-4ed5-9633-a1c6b931dd7d",
+    "data-project-name": "Move Book",
+    "data-project-color": "#298DFF",
+    "data-button-hide": "true",
+    "data-view-mode": "sidebar",
+    "data-modal-title": "Ask Move AI",
+    "data-modal-ask-ai-input-placeholder": "Ask me anything about Move!",
+    "data-modal-example-questions": "How do I define a struct in Move?,What are abilities in Move?,How do I publish a Move package?,What are dynamic fields?",
+    "data-modal-overlay-hidden": "true",
+    "data-modal-lock-scroll": "false",
+    "data-modal-image": "/favicon.svg",
+    "data-color-scheme-selector": "[data-theme='dark']",
+  };
+  for (const [key, value] of Object.entries(attrs)) {
+    script.setAttribute(key, value);
+  }
+  document.head.appendChild(script);
+
+  // Sidebar open/close detection
   const OPEN_CLASS = "kapa-sidebar-open";
   let kapaOpen = false;
   let hookedRef = null;
@@ -43,12 +65,9 @@ if (typeof window !== "undefined") {
     const y = window.innerHeight / 2;
     const el = document.elementFromPoint(x, y);
     if (!el) return false;
-    // If the element at the right edge is inside #__docusaurus, sidebar is closed
     const docRoot = document.getElementById("__docusaurus");
     if (docRoot && docRoot.contains(el)) return false;
-    // If it's the body or html itself, sidebar is closed
     if (el === document.body || el === document.documentElement) return false;
-    // Otherwise something (Kapa) is covering that spot
     return true;
   }
 

--- a/site/src/css/custom.css
+++ b/site/src/css/custom.css
@@ -141,3 +141,99 @@ html {
   padding: 0;
   font-size: 2.25em;
 }
+
+/* ---- Kapa sidebar content shift ---- */
+/* Kapa renders in Shadow DOM so CSS :has() can't detect it.
+   A client module (kapa-sidebar.js) toggles .kapa-sidebar-open on <html>. */
+html.kapa-sidebar-open body {
+  width: calc(100vw - 500px) !important;
+  overflow-x: hidden;
+  transition: width 0.3s ease;
+}
+
+html.kapa-sidebar-open .navbar,
+html.kapa-sidebar-open .navbar--fixed-top {
+  right: 500px !important;
+  overflow: hidden;
+  transition: right 0.3s ease;
+}
+
+/* Hide the Ask AI and Search buttons in navbar when sidebar is open
+   since Kapa is already visible */
+html.kapa-sidebar-open .kapa-trigger-btn,
+html.kapa-sidebar-open .DocSearch-Button,
+html.kapa-sidebar-open [class*="searchBarContainer"] {
+  display: none !important;
+}
+
+.navbar,
+.navbar--fixed-top {
+  transition: right 0.3s ease;
+}
+
+/* Hide the desktop TOC column when sidebar is open to free space */
+html.kapa-sidebar-open .col.col--3:has(.theme-doc-toc-desktop) {
+  display: none;
+}
+
+/* Let the main content column expand to fill the freed space */
+html.kapa-sidebar-open .col[class*="docItemCol"] {
+  max-width: 100% !important;
+  flex: 1 !important;
+}
+
+body {
+  transition: width 0.3s ease;
+}
+
+@media (max-width: 768px) {
+  html.kapa-sidebar-open body {
+    width: 100vw !important;
+  }
+}
+
+/* Kapa trigger button styles */
+.kapa-trigger-btn {
+  display: flex;
+  align-items: center;
+  gap: 0.625rem;
+  cursor: pointer;
+  background: white;
+  color: #111827;
+  font-weight: 600;
+  font-size: 1rem;
+  padding: 0.625rem 1.25rem;
+  border-radius: 9999px;
+  border: 1px solid #e5e7eb;
+  transition: background-color 0.15s;
+}
+
+.kapa-trigger-btn:hover {
+  background: #f9fafb;
+}
+
+[data-theme='dark'] .kapa-trigger-btn {
+  background: #374151;
+  color: #f3f4f6;
+  border-color: #4b5563;
+}
+
+[data-theme='dark'] .kapa-trigger-btn:hover {
+  background: #4b5563;
+}
+
+/* Compact kapa button below full desktop width */
+@media screen and (max-width: 1399px) {
+  .navbar .kapa-trigger-btn {
+    width: 42px;
+    height: 42px;
+    min-width: 42px;
+    padding: 0 !important;
+    justify-content: center;
+    margin: 0;
+  }
+
+  .navbar .kapa-trigger-btn span {
+    display: none;
+  }
+}

--- a/site/src/css/custom.css
+++ b/site/src/css/custom.css
@@ -196,43 +196,34 @@ body {
 .kapa-trigger-btn {
   display: flex;
   align-items: center;
-  gap: 0.625rem;
+  gap: 0.4rem;
   cursor: pointer;
-  background: white;
-  color: #111827;
-  font-weight: 600;
-  font-size: 1rem;
-  padding: 0.625rem 1.25rem;
-  border-radius: 9999px;
-  border: 1px solid #e5e7eb;
-  transition: background-color 0.15s;
+  background: none;
+  color: var(--ifm-font-color-base);
+  font-family: var(--ifm-font-family-base);
+  font-weight: var(--ifm-font-weight-bold);
+  font-size: var(--ifm-menu-link-font-size);
+  padding: 0.4rem 0.6rem;
+  border-radius: 4px;
+  border: none;
+  transition: color 0.15s, background-color 0.15s;
 }
 
 .kapa-trigger-btn:hover {
-  background: #f9fafb;
+  color: var(--ifm-menu-color-active);
+  background: var(--ifm-menu-color-background-hover);
 }
 
 [data-theme='dark'] .kapa-trigger-btn {
-  background: #374151;
-  color: #f3f4f6;
-  border-color: #4b5563;
+  color: var(--ifm-font-color-base);
 }
 
 [data-theme='dark'] .kapa-trigger-btn:hover {
-  background: #4b5563;
+  color: var(--ifm-menu-color-active);
 }
 
 /* Compact kapa button below full desktop width */
-@media screen and (max-width: 1399px) {
-  .navbar .kapa-trigger-btn {
-    width: 42px;
-    height: 42px;
-    min-width: 42px;
-    padding: 0 !important;
-    justify-content: center;
-    margin: 0;
-  }
-
+@media screen and (max-width: 996px) {
   .navbar .kapa-trigger-btn span {
     display: none;
   }

--- a/site/src/theme/Navbar/Content/index.js
+++ b/site/src/theme/Navbar/Content/index.js
@@ -1,0 +1,105 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+import * as React from "react";
+import { useThemeConfig, ErrorCauseBoundary } from "@docusaurus/theme-common";
+import {
+  splitNavbarItems,
+  useNavbarMobileSidebar,
+} from "@docusaurus/theme-common/internal";
+import NavbarItem from "@theme/NavbarItem";
+import NavbarMobileSidebarToggle from "@theme/Navbar/MobileSidebar/Toggle";
+import NavbarLogo from "@theme/Navbar/Logo";
+import NavbarSearch from "@theme/Navbar/Search";
+import SearchBar from "@theme/SearchBar";
+
+function useNavbarItems() {
+  return useThemeConfig().navbar.items;
+}
+
+function useMobileSidebarSafe() {
+  try {
+    return useNavbarMobileSidebar();
+  } catch {
+    return { disabled: true, toggle: () => {} };
+  }
+}
+
+function NavbarItems({ items }) {
+  return (
+    <>
+      {items.map((item, i) => (
+        <ErrorCauseBoundary
+          key={i}
+          onError={(error) =>
+            new Error(
+              `A theme navbar item failed to render.
+Please double-check the following navbar item (themeConfig.navbar.items) of your Docusaurus config:
+${JSON.stringify(item, null, 2)}`,
+              { cause: error },
+            )
+          }
+        >
+          <NavbarItem {...item} />
+        </ErrorCauseBoundary>
+      ))}
+    </>
+  );
+}
+
+function NavbarContentLayout({ left, right }) {
+  return (
+    <div className="navbar__inner">
+      <div className="navbar__items">{left}</div>
+      <div className="navbar__items navbar__items--right">{right}</div>
+    </div>
+  );
+}
+
+function KapaButton() {
+  const handleClick = () => {
+    if (typeof window !== "undefined" && window.Kapa) {
+      window.Kapa.open();
+    }
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      className="kapa-trigger-btn"
+    >
+      <img src="/favicon.svg" alt="" width="23" height="23" />
+      <span>Ask Move AI</span>
+    </button>
+  );
+}
+
+export default function NavbarContent() {
+  const mobileSidebar = useMobileSidebarSafe();
+  const items = useNavbarItems();
+  const [leftItems, rightItems] = splitNavbarItems(items);
+  const searchBarItem = items.find((item) => item.type === "search");
+
+  return (
+    <NavbarContentLayout
+      left={
+        <>
+          {!mobileSidebar.disabled && <NavbarMobileSidebarToggle />}
+          <NavbarLogo />
+          <NavbarItems items={leftItems} />
+        </>
+      }
+      right={
+        <>
+          <NavbarItems items={rightItems} />
+          <KapaButton />
+          {searchBarItem && (
+            <NavbarSearch>
+              <SearchBar />
+            </NavbarSearch>
+          )}
+        </>
+      }
+    />
+  );
+}

--- a/site/src/theme/Navbar/Content/index.js
+++ b/site/src/theme/Navbar/Content/index.js
@@ -10,6 +10,7 @@ import NavbarItem from "@theme/NavbarItem";
 import NavbarMobileSidebarToggle from "@theme/Navbar/MobileSidebar/Toggle";
 import NavbarLogo from "@theme/Navbar/Logo";
 import NavbarSearch from "@theme/Navbar/Search";
+import NavbarColorModeToggle from "@theme/Navbar/ColorModeToggle";
 import SearchBar from "@theme/SearchBar";
 
 function useNavbarItems() {
@@ -27,21 +28,25 @@ function useMobileSidebarSafe() {
 function NavbarItems({ items }) {
   return (
     <>
-      {items.map((item, i) => (
-        <ErrorCauseBoundary
-          key={i}
-          onError={(error) =>
-            new Error(
-              `A theme navbar item failed to render.
+      {items.map((item, i) => {
+        // Skip the search item — we render SearchBar separately
+        if (item.type === "search") return null;
+        return (
+          <ErrorCauseBoundary
+            key={i}
+            onError={(error) =>
+              new Error(
+                `A theme navbar item failed to render.
 Please double-check the following navbar item (themeConfig.navbar.items) of your Docusaurus config:
 ${JSON.stringify(item, null, 2)}`,
-              { cause: error },
-            )
-          }
-        >
-          <NavbarItem {...item} />
-        </ErrorCauseBoundary>
-      ))}
+                { cause: error },
+              )
+            }
+          >
+            <NavbarItem {...item} />
+          </ErrorCauseBoundary>
+        );
+      })}
     </>
   );
 }
@@ -78,7 +83,6 @@ export default function NavbarContent() {
   const mobileSidebar = useMobileSidebarSafe();
   const items = useNavbarItems();
   const [leftItems, rightItems] = splitNavbarItems(items);
-  const searchBarItem = items.find((item) => item.type === "search");
 
   return (
     <NavbarContentLayout
@@ -92,12 +96,11 @@ export default function NavbarContent() {
       right={
         <>
           <NavbarItems items={rightItems} />
+          <NavbarColorModeToggle />
           <KapaButton />
-          {searchBarItem && (
-            <NavbarSearch>
-              <SearchBar />
-            </NavbarSearch>
-          )}
+          <NavbarSearch>
+            <SearchBar />
+          </NavbarSearch>
         </>
       }
     />

--- a/site/src/theme/Navbar/Content/index.js
+++ b/site/src/theme/Navbar/Content/index.js
@@ -73,7 +73,6 @@ function KapaButton() {
       onClick={handleClick}
       className="kapa-trigger-btn"
     >
-      <img src="/favicon.svg" alt="" width="23" height="23" />
       <span>Ask Move AI</span>
     </button>
   );


### PR DESCRIPTION
## Summary
- Add Kapa.ai widget configured in sidebar mode with hidden default button
- Add custom Navbar component with "Ask Move AI" trigger button
- Add `kapa-sidebar.js` client module to detect sidebar open/close state and toggle CSS class on `<html>`
- Add CSS rules for 500px content shift, navbar adjustment, TOC hiding, and mobile responsiveness

## Test plan
- [ ] Run `pnpm build` locally to verify no build errors
- [ ] Verify Kapa widget loads on the site (requires `KAPA_API_KEY_MOVE_BOOK` secret)
- [ ] Click "Ask Move AI" button in navbar — sidebar should open on the right
- [ ] Verify content shifts left by 500px when sidebar is open
- [ ] Verify sidebar goes full-screen on mobile (< 768px)
- [ ] Verify button collapses to icon-only below 1400px viewport width

🤖 Generated with [Claude Code](https://claude.com/claude-code)