### PR TITLE
Fix inconsistent comment formatting in todo_list_tests.move

### DIFF
--- a/packages/todo_list/tests/todo_list_tests.move
+++ b/packages/todo_list/tests/todo_list_tests.move
@@ -29,23 +29,23 @@ module todo_list::todo_list_tests {
     // fun test_todo() {
     //     let ctx = &mut tx_context::dummy();
     //     let (mut list, cap) = todo_list::new(ctx);
-
+    //
     //     cap.add(&mut list, b"Clean the apartment".to_string());
     //     cap.add(&mut list, b"Buy groceries".to_string());
-
+    //
     //     assert!(list.length() == 2, 0);
     //     assert!(cap.remove(&mut list, 0) == b"Clean the apartment".to_string(), 0);
     //     assert!(list.length() == 1, 0);
-
+    //
     //     let guest = cap.invite(&list, ctx);
-
+    //
     //     guest.add(&mut list, b"Walk the dog".to_string());
-
+    //
     //     assert!(cap.remove(&mut list, 0) == b"Buy groceries".to_string(), 1);
     //     assert!(guest.remove(&mut list, 0) == b"Walk the dog".to_string(), 2);
-
+    //
     //     assert!(list.length() == 0, 3);
-
+    //
     //     guest.leave();
     //     list.delete(cap);
     // }


### PR DESCRIPTION
Standardize comment formatting in the commented-out test function by
replacing blank lines with properly formatted empty comment lines (//).
This ensures consistent comment block structure throughout the test file.