### PR TITLE
docs: User destroy from unit_test module

### DIFF
--- a/book/guides/code-quality-checklist.md
+++ b/book/guides/code-quality-checklist.md
@@ -565,7 +565,7 @@ nft.destroy_for_testing();
 app.destroy_for_testing();
 
 // good! - no need to define special functions for cleanup
-use sui::test_utils::destroy;
+use std::unit_test::destroy;
 
 destroy(nft);
 destroy(app);


### PR DESCRIPTION
### Overview 
sui::test_utils::destroy is deprecated, update checklist use new unit_test:destroy